### PR TITLE
Fix widget countdown alignment and let Settings choose which prayer times widgets show

### DIFF
--- a/android/app/src/main/kotlin/com/developer110/shiacompanion/widgets/ShiaCompanionGlanceWidgets.kt
+++ b/android/app/src/main/kotlin/com/developer110/shiacompanion/widgets/ShiaCompanionGlanceWidgets.kt
@@ -71,7 +71,6 @@ private const val KEY_RECITATION_SCHEDULE = "sc_recitation_schedule"
 private const val KEY_PRAYER_TITLE = "sc_prayer_title"
 private const val KEY_PRAYER_NAME = "sc_prayer_name"
 private const val KEY_PRAYER_TIME = "sc_prayer_time"
-private const val KEY_PRAYER_DATE = "sc_prayer_date"
 private const val KEY_PRAYER_LOCATION = "sc_prayer_location"
 private const val KEY_PRAYER_SCHEDULE = "sc_prayer_schedule"
 private const val KEY_PRAYER_SECONDARY_NAME = "sc_prayer_secondary_name"
@@ -313,13 +312,6 @@ private fun PrayerWidgetContent() {
             ),
             maxLines = 1
         )
-        if (prayer.dateLabel.isNotBlank()) {
-            Text(
-                text = prayer.dateLabel,
-                style = TextStyle(color = secondaryTextColor, fontSize = 12.sp),
-                maxLines = 1
-            )
-        }
         Spacer(GlanceModifier.defaultWeight())
         Text(
             text = footer,
@@ -641,7 +633,6 @@ private data class PrayerDisplay(
     val epochMillis: Long?,
     val name: String,
     val time: String,
-    val dateLabel: String,
     val location: String,
     val secondaryName: String,
     val secondaryTime: String
@@ -695,7 +686,6 @@ private data class PrayerEntry(
     val epochMillis: Long,
     val name: String,
     val time: String,
-    val dateLabel: String,
     val secondaryName: String,
     val secondaryTime: String
 )
@@ -713,7 +703,6 @@ private fun android.content.SharedPreferences.nextPrayer(): PrayerDisplay {
                 epochMillis = epochMillis,
                 name = parts[1],
                 time = parts[2],
-                dateLabel = parts[3],
                 secondaryName = parts.getOrNull(4).orEmpty(),
                 secondaryTime = parts.getOrNull(5).orEmpty()
             )
@@ -726,7 +715,6 @@ private fun android.content.SharedPreferences.nextPrayer(): PrayerDisplay {
             epochMillis = next.epochMillis,
             name = next.name,
             time = next.time,
-            dateLabel = next.dateLabel,
             location = location,
             secondaryName = next.secondaryName,
             secondaryTime = next.secondaryTime
@@ -737,7 +725,6 @@ private fun android.content.SharedPreferences.nextPrayer(): PrayerDisplay {
         epochMillis = null,
         name = text(KEY_PRAYER_NAME, "Prayer Times"),
         time = text(KEY_PRAYER_TIME, "Set location"),
-        dateLabel = text(KEY_PRAYER_DATE, "Open app"),
         location = location,
         secondaryName = text(KEY_PRAYER_SECONDARY_NAME, ""),
         secondaryTime = text(KEY_PRAYER_SECONDARY_TIME, "")

--- a/android/app/src/main/kotlin/com/developer110/shiacompanion/widgets/ShiaCompanionGlanceWidgets.kt
+++ b/android/app/src/main/kotlin/com/developer110/shiacompanion/widgets/ShiaCompanionGlanceWidgets.kt
@@ -77,8 +77,8 @@ private const val KEY_PRAYER_SECONDARY_NAME = "sc_prayer_secondary_name"
 private const val KEY_PRAYER_SECONDARY_TIME = "sc_prayer_secondary_time"
 
 private const val KEY_DAILY_PRAYER_TITLE = "sc_daily_prayer_title"
-private val dailyPrayerNameKeys = (1..5).map { "sc_daily_prayer_name_$it" }
-private val dailyPrayerTimeKeys = (1..5).map { "sc_daily_prayer_time_$it" }
+private val dailyPrayerNameKeys = (1..6).map { "sc_daily_prayer_name_$it" }
+private val dailyPrayerTimeKeys = (1..6).map { "sc_daily_prayer_time_$it" }
 private const val KEY_DAILY_PRAYER_SCHEDULE = "sc_daily_prayer_schedule"
 
 private val backgroundColor = ColorProvider(
@@ -278,7 +278,7 @@ private fun PrayerWidgetContent() {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = data.text(KEY_PRAYER_TITLE, "Next Prayer")
+                text = data.text(KEY_PRAYER_TITLE, "Up Next")
                     .replace("Upcoming", "Next")
                     .replace(" Prayer", ""),
                 modifier = GlanceModifier.defaultWeight(),
@@ -329,7 +329,9 @@ private fun DailyPrayerTimesWidgetContent() {
     val location = data.text(KEY_PRAYER_LOCATION, "Location needed")
     val nextPrayer = data.nextPrayer()
     val countdown = nextPrayer.countdownText()
-    val visiblePrayers = prayers.take(5)
+    val visiblePrayers = prayers.take(6)
+    // Six columns only fit a medium widget once the gutters tighten up.
+    val columnSpacingDp = if (visiblePrayers.size > 5) 2 else 4
 
     WidgetSurface(clickable = true, contentPadding = 10) {
         Row(
@@ -381,7 +383,7 @@ private fun DailyPrayerTimesWidgetContent() {
             visiblePrayers.forEachIndexed { index, prayer ->
                 PrayerTimeColumn(prayer)
                 if (index != visiblePrayers.lastIndex) {
-                    Spacer(GlanceModifier.width(4.dp))
+                    Spacer(GlanceModifier.width(columnSpacingDp.dp))
                 }
             }
         }
@@ -673,11 +675,14 @@ private fun prayerIconRes(prayerName: String): Int {
     val name = prayerName.lowercase()
     return when {
         name.contains("fajr") -> R.drawable.ic_prayer_fajr
+        name.contains("sunrise") -> R.drawable.ic_prayer_sunrise
         name.contains("zuhr") || name.contains("dhuhr") || name.contains("dhohr") ->
             R.drawable.ic_prayer_zuhr
         name.contains("asr") -> R.drawable.ic_prayer_asr
+        name.contains("sunset") -> R.drawable.ic_prayer_sunset
         name.contains("maghrib") -> R.drawable.ic_prayer_maghrib
         name.contains("isha") -> R.drawable.ic_prayer_isha
+        name.contains("midnight") -> R.drawable.ic_prayer_midnight
         else -> R.drawable.ic_prayer_zuhr
     }
 }
@@ -744,7 +749,7 @@ private fun android.content.SharedPreferences.dailyPrayerTimes(): List<DailyPray
     }
 
     return items
-        .take(5)
+        .take(6)
         .map { DailyPrayerTimeDisplay(title = it.title, time = it.time) }
 }
 

--- a/android/app/src/main/res/drawable/ic_prayer_midnight.xml
+++ b/android/app/src/main/res/drawable/ic_prayer_midnight.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M20,14.5A8,8 0 0 1 9.5,4A7.5,7.5 0 1 0 20,14.5Z"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_prayer_sunrise.xml
+++ b/android/app/src/main/res/drawable/ic_prayer_sunrise.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M3,19H21"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M8,19C8,16.79 9.79,15 12,15C14.21,15 16,16.79 16,19"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M12,3V8M8.5,9.5L12,6L15.5,9.5"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_prayer_sunset.xml
+++ b/android/app/src/main/res/drawable/ic_prayer_sunset.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M3,19H21"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M8,19C8,16.79 9.79,15 12,15C14.21,15 16,16.79 16,19"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M12,8V3M8.5,4.5L12,8L15.5,4.5"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,9 +3,9 @@
     <string name="widget_favorites_name">Favorites</string>
     <string name="widget_recitations_name">Today\'s Recitations</string>
     <string name="widget_daily_prayer_name">Prayer Times</string>
-    <string name="widget_prayer_name">Next Prayer</string>
+    <string name="widget_prayer_name">Up Next</string>
     <string name="widget_favorites_description">Saved Shia Companion favorites.</string>
     <string name="widget_recitations_description">Daily recitations from Shia Companion.</string>
-    <string name="widget_daily_prayer_description">All five daily prayer times for your saved location.</string>
-    <string name="widget_prayer_description">The next prayer time for your saved location.</string>
+    <string name="widget_daily_prayer_description">The prayer times you picked in Settings, for your saved location.</string>
+    <string name="widget_prayer_description">The next of the times you picked in Settings, for your saved location.</string>
 </resources>

--- a/ios/Runner/AppDelegate.m
+++ b/ios/Runner/AppDelegate.m
@@ -188,7 +188,7 @@ static NSString *const kWatchUpdatedAtKey = @"sc_watch_updated_at";
       @"sc_prayer_secondary_time",
       @"sc_daily_prayer_schedule",
     ] mutableCopy];
-    for (NSInteger index = 1; index <= 5; index++) {
+    for (NSInteger index = 1; index <= 6; index++) {
       [mutableKeys addObject:[NSString stringWithFormat:@"sc_daily_prayer_name_%ld", (long)index]];
       [mutableKeys addObject:[NSString stringWithFormat:@"sc_daily_prayer_time_%ld", (long)index]];
     }

--- a/ios/ShiaCompanion Watch App/ContentView.swift
+++ b/ios/ShiaCompanion Watch App/ContentView.swift
@@ -48,7 +48,7 @@ struct ContentView: View {
                 .padding(.top, 4)
             }
 
-            // Next Prayer Banner
+            // Up Next Banner
             if !prayerModel.nextPrayerName.isEmpty {
                 VStack(spacing: 4) {
                     Text(nextPrayerHeading)
@@ -127,8 +127,8 @@ struct ContentView: View {
 
     private var nextPrayerHeading: String {
         let label = prayerModel.nextPrayerDayLabel
-        guard !label.isEmpty, label != "Today" else { return "Next Prayer" }
-        return "Next Prayer · \(label)"
+        guard !label.isEmpty, label != "Today" else { return "Up Next" }
+        return "Up Next · \(label)"
     }
 }
 

--- a/ios/ShiaCompanion Watch App/PrayerDataStore.swift
+++ b/ios/ShiaCompanion Watch App/PrayerDataStore.swift
@@ -19,8 +19,8 @@ nonisolated enum WatchDataKeys {
     static let prayerSecondaryName = "sc_prayer_secondary_name"
     static let prayerSecondaryTime = "sc_prayer_secondary_time"
 
-    static let dailyPrayerNames = (1...5).map { "sc_daily_prayer_name_\($0)" }
-    static let dailyPrayerTimes = (1...5).map { "sc_daily_prayer_time_\($0)" }
+    static let dailyPrayerNames = (1...6).map { "sc_daily_prayer_name_\($0)" }
+    static let dailyPrayerTimes = (1...6).map { "sc_daily_prayer_time_\($0)" }
     static let dailyPrayerSchedule = "sc_daily_prayer_schedule"
 
     /// Epoch millis of the last payload the phone sent. Absent until the first sync.

--- a/ios/ShiaCompanionWatchWidgets/ShiaCompanionWatchWidgets.swift
+++ b/ios/ShiaCompanionWatchWidgets/ShiaCompanionWatchWidgets.swift
@@ -229,8 +229,8 @@ struct NextPrayerComplication: Widget {
             NextPrayerComplicationView(entry: entry)
                 .widgetContainerBackground()
         }
-        .configurationDisplayName("Next Prayer")
-        .description("The next prayer time for your saved location.")
+        .configurationDisplayName("Up Next")
+        .description("The next of the times you picked in Settings, for your saved location.")
         .supportedFamilies([
             .accessoryCircular,
             .accessoryCorner,

--- a/ios/ShiaCompanionWidgets/ShiaCompanionWidgets.swift
+++ b/ios/ShiaCompanionWidgets/ShiaCompanionWidgets.swift
@@ -22,8 +22,8 @@ private enum WidgetKeys {
     static let prayerSecondaryTime = "sc_prayer_secondary_time"
 
     static let dailyPrayerTitle = "sc_daily_prayer_title"
-    static let dailyPrayerNames = (1...5).map { "sc_daily_prayer_name_\($0)" }
-    static let dailyPrayerTimes = (1...5).map { "sc_daily_prayer_time_\($0)" }
+    static let dailyPrayerNames = (1...6).map { "sc_daily_prayer_name_\($0)" }
+    static let dailyPrayerTimes = (1...6).map { "sc_daily_prayer_time_\($0)" }
     static let dailyPrayerSchedule = "sc_daily_prayer_schedule"
 }
 
@@ -200,6 +200,7 @@ struct DailyPrayerTimesProvider: TimelineProvider {
             title: "Prayer Times",
             items: [
                 WidgetListItem(title: "Fajr", time: "05:00 am"),
+                WidgetListItem(title: "Sunrise", time: "06:24 am"),
                 WidgetListItem(title: "Zuhr", time: "12:30 pm"),
                 WidgetListItem(title: "Asr", time: "04:15 pm"),
                 WidgetListItem(title: "Maghrib", time: "08:10 pm"),
@@ -377,7 +378,7 @@ struct PrayerProvider: TimelineProvider {
     func placeholder(in context: Context) -> PrayerWidgetEntry {
         PrayerWidgetEntry(
             date: Date(),
-            title: "Next Prayer",
+            title: "Up Next",
             name: "Prayer Times",
             time: "Set location",
             location: "Location needed",
@@ -429,7 +430,7 @@ struct PrayerProvider: TimelineProvider {
 
         return PrayerWidgetEntry(
             date: now,
-            title: (defaults?.widgetString(WidgetKeys.prayerTitle, fallback: "Next Prayer") ?? "Next Prayer")
+            title: (defaults?.widgetString(WidgetKeys.prayerTitle, fallback: "Up Next") ?? "Up Next")
                 .replacingOccurrences(of: "Upcoming", with: "Next"),
             name: nextPrayer?.name ?? defaults?.widgetString(WidgetKeys.prayerName, fallback: "Prayer Times") ?? "Prayer Times",
             time: nextPrayer?.time ?? defaults?.widgetString(WidgetKeys.prayerTime, fallback: "Set location") ?? "Set location",
@@ -535,8 +536,10 @@ struct DailyPrayerTimesView: View {
     let entry: WidgetListEntry
 
     var body: some View {
-        let visibleItems = Array(entry.items.prefix(5))
+        let visibleItems = Array(entry.items.prefix(6))
         let hasPrayerTimes = visibleItems.contains { !$0.time.isEmpty }
+        // Six columns only fit a medium widget once the gutters tighten up.
+        let columnSpacing: CGFloat = visibleItems.count > 5 ? 4 : 8
 
         VStack(alignment: .leading, spacing: 5) {
             HStack(alignment: .center, spacing: 6) {
@@ -567,7 +570,7 @@ struct DailyPrayerTimesView: View {
             }
             Spacer(minLength: 0)
             if hasPrayerTimes {
-                HStack(alignment: .center, spacing: 8) {
+                HStack(alignment: .center, spacing: columnSpacing) {
                     ForEach(Array(visibleItems.enumerated()), id: \.offset) { _, item in
                         VStack(spacing: 4) {
                             PrayerGlyph(prayerName: item.title, badgeSize: 25, symbolSize: 13)
@@ -575,12 +578,13 @@ struct DailyPrayerTimesView: View {
                                 .font(.caption2.weight(.semibold))
                                 .foregroundColor(.secondaryText)
                                 .lineLimit(1)
+                                .minimumScaleFactor(0.7)
                                 .frame(maxWidth: .infinity)
                             Text(item.time)
                                 .font(.caption2.weight(.bold))
                                 .foregroundColor(.bodyText)
                                 .lineLimit(1)
-                                .minimumScaleFactor(0.72)
+                                .minimumScaleFactor(0.6)
                                 .frame(maxWidth: .infinity)
                         }
                         .frame(maxWidth: .infinity)
@@ -666,17 +670,23 @@ private func prayerSymbolName(for prayerName: String) -> String {
     if name.contains("fajr") {
         return "sunrise"
     }
+    if name.contains("sunrise") {
+        return "sunrise.fill"
+    }
     if name.contains("zuhr") || name.contains("dhuhr") || name.contains("dhohr") {
         return "sun.max"
     }
     if name.contains("asr") {
         return "sun.min"
     }
-    if name.contains("maghrib") {
+    if name.contains("maghrib") || name.contains("sunset") {
         return "sunset"
     }
     if name.contains("isha") {
         return "moon.stars"
+    }
+    if name.contains("midnight") {
+        return "moon"
     }
     return "sun.max"
 }
@@ -766,7 +776,7 @@ struct DailyPrayerTimesWidget: Widget {
             DailyPrayerTimesView(entry: entry)
         }
         .configurationDisplayName("Prayer Times")
-        .description("All five daily prayer times for your saved location.")
+        .description("The prayer times you picked in Settings, for your saved location.")
         .supportedFamilies([.systemMedium])
     }
 }
@@ -778,8 +788,8 @@ struct UpcomingPrayerWidget: Widget {
         StaticConfiguration(kind: kind, provider: PrayerProvider()) { entry in
             PrayerWidgetView(entry: entry)
         }
-        .configurationDisplayName("Next Prayer")
-        .description("The next prayer time for your saved location.")
+        .configurationDisplayName("Up Next")
+        .description("The next of the times you picked in Settings, for your saved location.")
         .supportedFamilies([.systemSmall])
     }
 }

--- a/ios/ShiaCompanionWidgets/ShiaCompanionWidgets.swift
+++ b/ios/ShiaCompanionWidgets/ShiaCompanionWidgets.swift
@@ -16,7 +16,6 @@ private enum WidgetKeys {
     static let prayerTitle = "sc_prayer_title"
     static let prayerName = "sc_prayer_name"
     static let prayerTime = "sc_prayer_time"
-    static let prayerDate = "sc_prayer_date"
     static let prayerLocation = "sc_prayer_location"
     static let prayerSchedule = "sc_prayer_schedule"
     static let prayerSecondaryName = "sc_prayer_secondary_name"
@@ -360,7 +359,6 @@ struct PrayerWidgetEntry: TimelineEntry {
     let title: String
     let name: String
     let time: String
-    let dateLabel: String
     let location: String
     let secondaryName: String
     let secondaryTime: String
@@ -371,7 +369,6 @@ private struct PrayerScheduleEntry {
     let date: Date
     let name: String
     let time: String
-    let dateLabel: String
     let secondaryName: String
     let secondaryTime: String
 }
@@ -383,7 +380,6 @@ struct PrayerProvider: TimelineProvider {
             title: "Next Prayer",
             name: "Prayer Times",
             time: "Set location",
-            dateLabel: "Open app",
             location: "Location needed",
             secondaryName: "",
             secondaryTime: "",
@@ -437,7 +433,6 @@ struct PrayerProvider: TimelineProvider {
                 .replacingOccurrences(of: "Upcoming", with: "Next"),
             name: nextPrayer?.name ?? defaults?.widgetString(WidgetKeys.prayerName, fallback: "Prayer Times") ?? "Prayer Times",
             time: nextPrayer?.time ?? defaults?.widgetString(WidgetKeys.prayerTime, fallback: "Set location") ?? "Set location",
-            dateLabel: nextPrayer?.dateLabel ?? defaults?.widgetString(WidgetKeys.prayerDate, fallback: "Open app") ?? "Open app",
             location: defaults?.widgetString(WidgetKeys.prayerLocation, fallback: "Location needed") ?? "Location needed",
             secondaryName: nextPrayer?.secondaryName ?? defaults?.widgetString(WidgetKeys.prayerSecondaryName, fallback: "") ?? "",
             secondaryTime: nextPrayer?.secondaryTime ?? defaults?.widgetString(WidgetKeys.prayerSecondaryTime, fallback: "") ?? "",
@@ -462,7 +457,6 @@ private func parsePrayerSchedule(_ rawSchedule: String) -> [PrayerScheduleEntry]
                 date: Date(timeIntervalSince1970: epochMillis / 1000.0),
                 name: parts[1],
                 time: parts[2],
-                dateLabel: parts[3],
                 secondaryName: parts.count == 6 ? parts[4] : "",
                 secondaryTime: parts.count == 6 ? parts[5] : ""
             )
@@ -557,15 +551,18 @@ struct DailyPrayerTimesView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if !entry.nextPrayerName.isEmpty, let nextPrayerDate = entry.nextPrayerDate {
                     HStack(spacing: 3) {
-                        Text(entry.nextPrayerName)
-                        Text("in")
+                        Text("\(entry.nextPrayerName) in")
+                        // Timer text reserves room for the widest value it can
+                        // ever show, so it needs trailing alignment of its own
+                        // to sit flush against the edge of the widget.
                         Text(nextPrayerDate, style: .timer)
+                            .font(.caption2.weight(.bold).monospacedDigit())
+                            .multilineTextAlignment(.trailing)
                     }
                     .font(.caption2.weight(.bold))
                     .foregroundColor(.bodyText)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .layoutPriority(1)
                 }
             }
             Spacer(minLength: 0)
@@ -631,12 +628,6 @@ struct PrayerWidgetView: View {
                 .foregroundColor(.bodyText)
                 .minimumScaleFactor(0.75)
                 .lineLimit(1)
-            if !entry.dateLabel.isEmpty {
-                Text(entry.dateLabel)
-                    .font(.caption)
-                    .foregroundColor(.secondaryText)
-                    .lineLimit(1)
-            }
             Spacer(minLength: 2)
             Text(footer)
                 .font(.caption2)

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -16,7 +16,9 @@ import '../services/qaza_tracker_manager.dart';
 import '../services/session_refresh_service.dart';
 import '../utils/dark_mode.dart';
 import '../utils/external_launch.dart';
+import '../utils/prayer_time_icons.dart';
 import '../utils/shared_preferences.dart';
+import '../utils/widget_prayer_time_selection.dart';
 import '../widgets/responsive_content.dart';
 import '../widgets/zikr_reading_preferences.dart';
 import 'about_page.dart';
@@ -106,6 +108,15 @@ class _SettingsPageState extends State<SettingsPage> {
                   setState(() {});
                 },
               ),
+              if (!kIsWeb)
+                ListTile(
+                  leading: const Icon(Icons.widgets),
+                  title: const Text("Widget Prayer Times"),
+                  subtitle: Text(_widgetPrayerTimesSubtitle()),
+                  onTap: () {
+                    _showWidgetPrayerTimesDialog(context);
+                  },
+                ),
               if (!shouldUseLiveLocation())
                 ListTile(
                   leading: const Icon(Icons.location_on),
@@ -523,6 +534,90 @@ class _SettingsPageState extends State<SettingsPage> {
         return dialog;
       },
     );
+  }
+
+  String _widgetPrayerTimesSubtitle() {
+    final names =
+        selectedWidgetPrayerTimes().map((time) => time.name).join(', ');
+    return "Shown on the home screen widgets: $names.";
+  }
+
+  void _showWidgetPrayerTimesDialog(BuildContext context) {
+    final selected =
+        selectedWidgetPrayerTimes().map((time) => time.id).toSet();
+
+    showDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return StatefulBuilder(
+          builder: (BuildContext context, StateSetter setDialogState) {
+            final atMinimum = selected.length <= minWidgetPrayerTimes;
+            final atMaximum = selected.length >= maxWidgetPrayerTimes;
+
+            return AlertDialog(
+              title: const Text("Widget Prayer Times"),
+              content: SizedBox(
+                width: double.maxFinite,
+                child: ListView(
+                  shrinkWrap: true,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                      child: Text(
+                        "Pick $minWidgetPrayerTimes to $maxWidgetPrayerTimes "
+                        "times. Sunrise, Sunset and Midnight are the deadlines "
+                        "a prayer has to be offered before.",
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ),
+                    for (final time in widgetPrayerTimes)
+                      CheckboxListTile(
+                        dense: true,
+                        secondary: Icon(prayerIconFor(time.name)),
+                        title: Text(time.name),
+                        value: selected.contains(time.id),
+                        onChanged: (selected.contains(time.id)
+                                ? atMinimum
+                                : atMaximum)
+                            ? null
+                            : (bool? value) {
+                                setDialogState(() {
+                                  if (value == true) {
+                                    selected.add(time.id);
+                                  } else {
+                                    selected.remove(time.id);
+                                  }
+                                });
+                              },
+                      ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(dialogContext),
+                  child: const Text("Cancel"),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    Navigator.pop(dialogContext);
+                    await _saveWidgetPrayerTimes(selected.toList());
+                  },
+                  child: const Text("Save"),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _saveWidgetPrayerTimes(List<String> ids) async {
+    await saveWidgetPrayerTimes(ids);
+    await HomeScreenWidgetService.instance.publishAll();
+    if (!mounted) return;
+    setState(() {});
   }
 
   saveHijriDate() async {

--- a/lib/pages/widget_preview_page.dart
+++ b/lib/pages/widget_preview_page.dart
@@ -129,7 +129,7 @@ class _WidgetPreviewPageState extends State<WidgetPreviewPage> {
                     width: 180,
                     height: 180,
                     title: data[HomeScreenWidgetService.prayerTitleKey] ??
-                        'Next Prayer',
+                        'Up Next',
                     name:
                         data[HomeScreenWidgetService.prayerNameKey] ?? 'Prayer',
                     time: data[HomeScreenWidgetService.prayerTimeKey] ?? '',
@@ -432,7 +432,7 @@ class _DailyPrayerTimesWidgetPreview extends StatelessWidget {
     final palette = _WidgetPalette.of(context);
     final visibleItems = items
         .where((item) => item.name.isNotEmpty || item.time.isNotEmpty)
-        .take(5)
+        .take(6)
         .toList();
 
     return _WidgetShell(
@@ -517,7 +517,8 @@ class _DailyPrayerTimesWidgetPreview extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (i != visibleItems.length - 1) const SizedBox(width: 6),
+                if (i != visibleItems.length - 1)
+                  SizedBox(width: visibleItems.length > 5 ? 2 : 6),
               ],
             ],
           ),

--- a/lib/pages/widget_preview_page.dart
+++ b/lib/pages/widget_preview_page.dart
@@ -133,8 +133,6 @@ class _WidgetPreviewPageState extends State<WidgetPreviewPage> {
                     name:
                         data[HomeScreenWidgetService.prayerNameKey] ?? 'Prayer',
                     time: data[HomeScreenWidgetService.prayerTimeKey] ?? '',
-                    dateLabel:
-                        data[HomeScreenWidgetService.prayerDateKey] ?? '',
                     location:
                         data[HomeScreenWidgetService.prayerLocationKey] ?? '',
                     secondaryName:
@@ -336,7 +334,6 @@ class _PrayerWidgetPreview extends StatelessWidget {
     required this.title,
     required this.name,
     required this.time,
-    required this.dateLabel,
     required this.location,
     required this.secondaryName,
     required this.secondaryTime,
@@ -347,7 +344,6 @@ class _PrayerWidgetPreview extends StatelessWidget {
   final String title;
   final String name;
   final String time;
-  final String dateLabel;
   final String location;
   final String secondaryName;
   final String secondaryTime;
@@ -398,11 +394,6 @@ class _PrayerWidgetPreview extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
               style:
                   const TextStyle(fontSize: 28, fontWeight: FontWeight.w800)),
-          if (dateLabel.isNotEmpty)
-            Text(dateLabel,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(fontSize: 12, color: palette.secondaryText)),
           const Spacer(),
           Text(footer,
               maxLines: 1,

--- a/lib/services/home_screen_widget_service.dart
+++ b/lib/services/home_screen_widget_service.dart
@@ -8,8 +8,8 @@ import 'package:shia_companion/constants.dart';
 import 'package:shia_companion/data/uid_title_data.dart';
 import 'package:shia_companion/data/universal_data.dart';
 import 'package:shia_companion/utils/deep_links.dart';
-import 'package:shia_companion/utils/prayer_time_entries.dart';
 import 'package:shia_companion/utils/todays_recitation.dart';
+import 'package:shia_companion/utils/widget_prayer_time_selection.dart';
 
 class HomeScreenWidgetService {
   HomeScreenWidgetService._();
@@ -67,7 +67,7 @@ class HomeScreenWidgetService {
 
   static const String dailyPrayerTimesTitleKey = 'sc_daily_prayer_title';
   static const String dailyPrayerTimesScheduleKey = 'sc_daily_prayer_schedule';
-  static const int dailyPrayerTimesItemCount = 5;
+  static const int dailyPrayerTimesItemCount = maxWidgetPrayerTimes;
   static final List<String> dailyPrayerNameKeys = List.generate(
     dailyPrayerTimesItemCount,
     (index) => 'sc_daily_prayer_name_${index + 1}',
@@ -200,7 +200,7 @@ class HomeScreenWidgetService {
   Map<String, String> buildUpcomingPrayerSnapshot() {
     final prayerSnapshot = _buildPrayerSnapshot();
     return {
-      prayerTitleKey: 'Next Prayer',
+      prayerTitleKey: 'Up Next',
       prayerNameKey: prayerSnapshot.name,
       prayerTimeKey: prayerSnapshot.time,
       prayerDateKey: prayerSnapshot.dateLabel,
@@ -235,8 +235,8 @@ class HomeScreenWidgetService {
 
     for (var index = 0; index < dailyPrayerTimesItemCount; index++) {
       final prayer = _itemAt(prayers, index);
-      snapshot[dailyPrayerNameKeys[index]] = prayer?.name ?? '';
-      snapshot[dailyPrayerTimeKeys[index]] = prayer?.time ?? '';
+      snapshot[dailyPrayerNameKeys[index]] = prayer?.time.name ?? '';
+      snapshot[dailyPrayerTimeKeys[index]] = prayer?.displayTime ?? '';
     }
 
     return snapshot;
@@ -328,69 +328,31 @@ class HomeScreenWidgetService {
 
   List<_PrayerScheduleEntry> _buildPrayerSchedule(DateTime now) {
     final schedule = <_PrayerScheduleEntry>[];
-    final prayerTime = getPrayerTimeObject();
-    final names = prayerTime.getTimeNames();
+    final selected = selectedWidgetPrayerTimes();
     final startOfToday = DateTime(now.year, now.month, now.day);
 
     for (var dayOffset = 0; dayOffset < 8; dayOffset++) {
       final date = startOfToday.add(Duration(days: dayOffset));
       final dateLabel = _dateLabelForDay(date, dayOffset);
+      // Every time, not just the selected ones, so a prayer can still name the
+      // deadline it has to be offered before even when that marker is hidden.
+      final readings = {
+        for (final reading in _readWidgetPrayerTimesForDay(date))
+          reading.time.id: reading,
+      };
 
-      prayerTime.setTimeFormat(prayerTime.getTime24());
-      final times24 = prayerTime.getPrayerTimes(
-        date,
-        lat!,
-        long!,
-        date.timeZoneOffset.inMinutes / 60.0,
-      );
+      for (final time in selected) {
+        final reading = readings[time.id];
+        if (reading == null) continue;
 
-      prayerTime.setTimeFormat(prayerTime.getTime12());
-      final displayTimes = prayerTime.getPrayerTimes(
-        date,
-        lat!,
-        long!,
-        date.timeZoneOffset.inMinutes / 60.0,
-      );
-
-      final midnight = shiaMidnightForDate(
-        prayerTime: prayerTime,
-        date: date,
-        latitude: lat!,
-        longitude: long!,
-      );
-      final periods = [
-        _PrayerPeriod(
-          index: prayerIndexFajr,
-          name: names[prayerIndexFajr],
-          secondaryName: 'Sunrise',
-          secondaryTime: displayTimes[prayerIndexSunrise],
-        ),
-        _PrayerPeriod(
-          index: prayerIndexZuhr,
-          name: names[prayerIndexZuhr],
-          secondaryName: 'Sunset',
-          secondaryTime: displayTimes[prayerIndexSunset],
-        ),
-        _PrayerPeriod(
-          index: prayerIndexMaghrib,
-          name: names[prayerIndexMaghrib],
-          secondaryName: 'Midnight',
-          secondaryTime:
-              midnight == null ? '' : formatPrayerDateTime12(midnight),
-        ),
-      ];
-
-      for (final period in periods) {
-        final dateTime = dateTimeForTime24(date, times24[period.index]);
-        if (dateTime == null) continue;
-
+        final offerBefore = readings[time.offerBeforeId];
         schedule.add(_PrayerScheduleEntry(
-          dateTime: dateTime,
-          name: period.name,
-          displayTime: displayTimes[period.index],
+          dateTime: reading.dateTime,
+          name: time.name,
+          displayTime: reading.displayTime,
           dateLabel: dateLabel,
-          secondaryName: period.secondaryName,
-          secondaryTime: period.secondaryTime,
+          secondaryName: offerBefore == null ? '' : offerBefore.time.name,
+          secondaryTime: offerBefore == null ? '' : offerBefore.displayTime,
         ));
       }
     }
@@ -399,13 +361,24 @@ class HomeScreenWidgetService {
     return schedule;
   }
 
-  List<PrayerTimeDisplayEntry> _buildDailyPrayerTimesForDay(DateTime date) {
-    return buildFiveDailyPrayerTimeEntries(
+  List<WidgetPrayerTimeReading> _readWidgetPrayerTimesForDay(
+    DateTime date, {
+    List<WidgetPrayerTime>? times,
+  }) {
+    return readWidgetPrayerTimes(
       prayerTime: getPrayerTimeObject(),
       date: date,
       latitude: lat!,
       longitude: long!,
       timeZone: date.timeZoneOffset.inMinutes / 60.0,
+      times: times ?? widgetPrayerTimes,
+    );
+  }
+
+  List<WidgetPrayerTimeReading> _buildDailyPrayerTimesForDay(DateTime date) {
+    return _readWidgetPrayerTimesForDay(
+      date,
+      times: selectedWidgetPrayerTimes(),
     );
   }
 
@@ -420,8 +393,8 @@ class HomeScreenWidgetService {
         'start': date.millisecondsSinceEpoch,
         'items': prayers
             .map((prayer) => {
-                  'title': prayer.name,
-                  'time': prayer.time,
+                  'title': prayer.time.name,
+                  'time': prayer.displayTime,
                   'url': '',
                 })
             .toList(),
@@ -489,20 +462,6 @@ class _PrayerSnapshot {
   final String dateLabel;
   final String location;
   final String encodedSchedule;
-  final String secondaryName;
-  final String secondaryTime;
-}
-
-class _PrayerPeriod {
-  const _PrayerPeriod({
-    required this.index,
-    required this.name,
-    required this.secondaryName,
-    required this.secondaryTime,
-  });
-
-  final int index;
-  final String name;
   final String secondaryName;
   final String secondaryTime;
 }

--- a/lib/utils/prayer_time_entries.dart
+++ b/lib/utils/prayer_time_entries.dart
@@ -64,40 +64,6 @@ List<PrayerTimeDisplayEntry> buildExtendedPrayerTimeEntries({
   }
 }
 
-List<PrayerTimeDisplayEntry> buildFiveDailyPrayerTimeEntries({
-  required PrayerTime prayerTime,
-  required DateTime date,
-  required double latitude,
-  required double longitude,
-  required double timeZone,
-}) {
-  final originalFormat = prayerTime.getTimeFormat();
-  try {
-    prayerTime.setTimeFormat(prayerTime.getTime12());
-    final names = prayerTime.getTimeNames();
-    final times =
-        prayerTime.getPrayerTimes(date, latitude, longitude, timeZone);
-    final indices = [
-      prayerIndexFajr,
-      prayerIndexZuhr,
-      prayerIndexAsr,
-      prayerIndexMaghrib,
-      prayerIndexIsha,
-    ];
-
-    return [
-      for (final index in indices)
-        PrayerTimeDisplayEntry(
-          name: names[index],
-          time: times[index],
-          notificationPrayerName: names[index],
-        ),
-    ];
-  } finally {
-    prayerTime.setTimeFormat(originalFormat);
-  }
-}
-
 DateTime? shiaMidnightForDate({
   required PrayerTime prayerTime,
   required DateTime date,

--- a/lib/utils/widget_prayer_time_selection.dart
+++ b/lib/utils/widget_prayer_time_selection.dart
@@ -1,0 +1,204 @@
+import 'package:shia_companion/utils/prayer_time_entries.dart';
+import 'package:shia_companion/utils/prayer_times.dart';
+import 'package:shia_companion/utils/shared_preferences.dart';
+
+/// Which times the home screen widgets show. Chosen once in Settings and shared
+/// by the prayer times list widget and the Up Next countdown, so both agree on
+/// what "next" means.
+///
+/// The five prayers are the default, but a prayer offered before it becomes
+/// qaza is bounded by Sunrise, Sunset or Midnight rather than by the next
+/// prayer, so those markers are selectable too.
+const String widgetPrayerTimesKey = 'widget_prayer_times';
+
+/// Fewer than three leaves the list widget looking broken; more than six stops
+/// the columns fitting a medium widget.
+const int minWidgetPrayerTimes = 3;
+const int maxWidgetPrayerTimes = 6;
+
+class WidgetPrayerTime {
+  const WidgetPrayerTime({
+    required this.id,
+    required this.name,
+    this.timeIndex,
+    this.offerBeforeId,
+  });
+
+  final String id;
+  final String name;
+
+  /// Index into [PrayerTime.getPrayerTimes], or null for times this app
+  /// computes itself.
+  final int? timeIndex;
+
+  /// The time this one has to be offered before. Shown as the Up Next footer so
+  /// the widget names the deadline, not just the start.
+  final String? offerBeforeId;
+}
+
+/// Every selectable time, in the order they occur.
+const List<WidgetPrayerTime> widgetPrayerTimes = <WidgetPrayerTime>[
+  WidgetPrayerTime(
+    id: 'fajr',
+    name: 'Fajr',
+    timeIndex: prayerIndexFajr,
+    offerBeforeId: 'sunrise',
+  ),
+  WidgetPrayerTime(
+    id: 'sunrise',
+    name: 'Sunrise',
+    timeIndex: prayerIndexSunrise,
+  ),
+  WidgetPrayerTime(
+    id: 'zuhr',
+    name: 'Zuhr',
+    timeIndex: prayerIndexZuhr,
+    offerBeforeId: 'sunset',
+  ),
+  WidgetPrayerTime(
+    id: 'asr',
+    name: 'Asr',
+    timeIndex: prayerIndexAsr,
+    offerBeforeId: 'sunset',
+  ),
+  WidgetPrayerTime(
+    id: 'sunset',
+    name: 'Sunset',
+    timeIndex: prayerIndexSunset,
+  ),
+  WidgetPrayerTime(
+    id: 'maghrib',
+    name: 'Maghrib',
+    timeIndex: prayerIndexMaghrib,
+    offerBeforeId: 'midnight',
+  ),
+  WidgetPrayerTime(
+    id: 'isha',
+    name: 'Isha',
+    timeIndex: prayerIndexIsha,
+    offerBeforeId: 'midnight',
+  ),
+  WidgetPrayerTime(id: 'midnight', name: 'Midnight'),
+];
+
+const List<String> defaultWidgetPrayerTimeIds = <String>[
+  'fajr',
+  'zuhr',
+  'asr',
+  'maghrib',
+  'isha',
+];
+
+/// A selected time resolved against the prayer engine for one day.
+class WidgetPrayerTimeReading {
+  const WidgetPrayerTimeReading({
+    required this.time,
+    required this.dateTime,
+    required this.displayTime,
+  });
+
+  final WidgetPrayerTime time;
+
+  /// Absolute instant, for countdowns and timeline transitions.
+  final DateTime dateTime;
+
+  /// 12-hour label, as the widgets render it.
+  final String displayTime;
+}
+
+/// The stored selection, de-duplicated and back in chronological order. Falls
+/// back to the five prayers whenever what is stored no longer resolves to a
+/// usable selection, so a widget never renders empty.
+List<WidgetPrayerTime> selectedWidgetPrayerTimes() {
+  final stored = SP.isInitialized
+      ? SP.prefs.getStringList(widgetPrayerTimesKey)
+      : null;
+  return resolveWidgetPrayerTimes(stored);
+}
+
+List<WidgetPrayerTime> resolveWidgetPrayerTimes(List<String>? ids) {
+  final wanted = <String>{...?ids};
+  final resolved = widgetPrayerTimes
+      .where((time) => wanted.contains(time.id))
+      .toList(growable: false);
+  if (resolved.length < minWidgetPrayerTimes ||
+      resolved.length > maxWidgetPrayerTimes) {
+    return defaultWidgetPrayerTimeSelection;
+  }
+  return resolved;
+}
+
+List<WidgetPrayerTime> get defaultWidgetPrayerTimeSelection => widgetPrayerTimes
+    .where((time) => defaultWidgetPrayerTimeIds.contains(time.id))
+    .toList(growable: false);
+
+Future<void> saveWidgetPrayerTimes(List<String> ids) async {
+  final resolved = resolveWidgetPrayerTimes(ids)
+      .map((time) => time.id)
+      .toList(growable: false);
+  await SP.prefs.setStringList(widgetPrayerTimesKey, resolved);
+}
+
+/// Resolves [times] for [date]. Times the engine cannot produce for the day —
+/// Midnight above the polar circles, for instance — are dropped rather than
+/// reported as an invalid string.
+List<WidgetPrayerTimeReading> readWidgetPrayerTimes({
+  required PrayerTime prayerTime,
+  required DateTime date,
+  required double latitude,
+  required double longitude,
+  required double timeZone,
+  required List<WidgetPrayerTime> times,
+}) {
+  final originalFormat = prayerTime.getTimeFormat();
+  try {
+    prayerTime.setTimeFormat(prayerTime.getTime24());
+    final times24 = prayerTime.getPrayerTimes(
+      date,
+      latitude,
+      longitude,
+      timeZone,
+    );
+
+    prayerTime.setTimeFormat(prayerTime.getTime12());
+    final displayTimes = prayerTime.getPrayerTimes(
+      date,
+      latitude,
+      longitude,
+      timeZone,
+    );
+
+    final midnight = shiaMidnightForDate(
+      prayerTime: prayerTime,
+      date: date,
+      latitude: latitude,
+      longitude: longitude,
+    );
+
+    final readings = <WidgetPrayerTimeReading>[];
+    for (final time in times) {
+      final index = time.timeIndex;
+      if (index == null) {
+        if (midnight == null) continue;
+        readings.add(WidgetPrayerTimeReading(
+          time: time,
+          dateTime: midnight,
+          displayTime: formatPrayerDateTime12(midnight),
+        ));
+        continue;
+      }
+
+      final dateTime = dateTimeForTime24(date, times24[index]);
+      if (dateTime == null) continue;
+      readings.add(WidgetPrayerTimeReading(
+        time: time,
+        dateTime: dateTime,
+        displayTime: displayTimes[index],
+      ));
+    }
+
+    return readings;
+  } finally {
+    prayerTime.setTimeFormat(originalFormat);
+  }
+}

--- a/test/prayer_time_entries_test.dart
+++ b/test/prayer_time_entries_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shia_companion/constants.dart';
 import 'package:shia_companion/utils/prayer_time_entries.dart';
+import 'package:shia_companion/utils/widget_prayer_time_selection.dart';
 
 void main() {
   test('dateTimeForTime24 parses HH:mm and rejects malformed input', () {
@@ -19,25 +20,94 @@ void main() {
     expect(formatPrayerDateTime12(DateTime(2024, 1, 1, 23, 9)), '11:09 pm');
   });
 
-  test('buildFiveDailyPrayerTimeEntries returns the five daily prayers in order', () {
+  test('readWidgetPrayerTimes returns the default five prayers in order', () {
     final prayerTime = getPrayerTimeObject();
     final originalFormat = prayerTime.getTimeFormat();
 
-    final entries = buildFiveDailyPrayerTimeEntries(
+    final readings = readWidgetPrayerTimes(
       prayerTime: prayerTime,
       date: DateTime(2024, 6, 16),
       latitude: 21.4225,
       longitude: 39.8262,
       timeZone: 3.0,
+      times: defaultWidgetPrayerTimeSelection,
     );
 
     expect(
-      entries.map((e) => e.name).toList(),
+      readings.map((reading) => reading.time.name).toList(),
       ['Fajr', 'Zuhr', 'Asr', 'Maghrib', 'Isha'],
     );
-    expect(entries.every((e) => e.canNotify), isTrue);
-    // The original time format must be restored after building entries.
+    expect(
+      readings.map((reading) => reading.dateTime).toList(),
+      orderedEquals(
+        List.of(readings.map((reading) => reading.dateTime))..sort(),
+      ),
+    );
+    // The original time format must be restored after resolving times.
     expect(prayerTime.getTimeFormat(), originalFormat);
+  });
+
+  test('readWidgetPrayerTimes resolves the daylight markers chronologically',
+      () {
+    final readings = readWidgetPrayerTimes(
+      prayerTime: getPrayerTimeObject(),
+      date: DateTime(2024, 6, 16),
+      latitude: 21.4225,
+      longitude: 39.8262,
+      timeZone: 3.0,
+      times: widgetPrayerTimes,
+    );
+
+    expect(
+      readings.map((reading) => reading.time.name).toList(),
+      [
+        'Fajr',
+        'Sunrise',
+        'Zuhr',
+        'Asr',
+        'Sunset',
+        'Maghrib',
+        'Isha',
+        'Midnight',
+      ],
+    );
+    for (var index = 1; index < readings.length; index++) {
+      expect(
+        readings[index].dateTime.isAfter(readings[index - 1].dateTime),
+        isTrue,
+        reason: '${readings[index].time.name} must follow '
+            '${readings[index - 1].time.name}',
+      );
+    }
+    expect(readings.every((reading) => reading.displayTime.isNotEmpty), isTrue);
+  });
+
+  test('resolveWidgetPrayerTimes falls back when the stored selection is unusable',
+      () {
+    expect(
+      resolveWidgetPrayerTimes(['fajr', 'maghrib']).map((time) => time.id),
+      defaultWidgetPrayerTimeIds,
+    );
+    expect(
+      resolveWidgetPrayerTimes(null).map((time) => time.id),
+      defaultWidgetPrayerTimeIds,
+    );
+    expect(
+      resolveWidgetPrayerTimes(widgetPrayerTimes.map((t) => t.id).toList())
+          .map((time) => time.id),
+      defaultWidgetPrayerTimeIds,
+    );
+    expect(
+      resolveWidgetPrayerTimes(['nonsense', 'fajr', 'sunrise', 'zuhr'])
+          .map((time) => time.id),
+      ['fajr', 'sunrise', 'zuhr'],
+    );
+    // Selections are stored as a set and read back in the order times occur.
+    expect(
+      resolveWidgetPrayerTimes(['sunset', 'fajr', 'sunrise'])
+          .map((time) => time.id),
+      ['fajr', 'sunrise', 'sunset'],
+    );
   });
 
   test('buildExtendedPrayerTimeEntries includes all seven names plus a Midnight entry', () {

--- a/test/widget_prayer_time_selection_test.dart
+++ b/test/widget_prayer_time_selection_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shia_companion/constants.dart';
+import 'package:shia_companion/services/home_screen_widget_service.dart';
+import 'package:shia_companion/utils/shared_preferences.dart';
+import 'package:shia_companion/utils/widget_prayer_time_selection.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SP.init();
+    city = 'Mecca';
+    lat = 21.4225;
+    long = 39.8262;
+  });
+
+  List<String> namesFrom(Map<String, String> snapshot) {
+    return [
+      for (final key in HomeScreenWidgetService.dailyPrayerNameKeys)
+        if ((snapshot[key] ?? '').isNotEmpty) snapshot[key]!,
+    ];
+  }
+
+  Set<String> scheduledNamesFrom(Map<String, String> snapshot) {
+    return (snapshot[HomeScreenWidgetService.prayerScheduleKey] ?? '')
+        .split(';')
+        .map((entry) => entry.split('|'))
+        .where((parts) => parts.length == 6)
+        .map((parts) => parts[1])
+        .toSet();
+  }
+
+  test('the prayer times widget shows the saved selection, in order', () async {
+    await saveWidgetPrayerTimes(
+      ['maghrib', 'fajr', 'sunset', 'sunrise', 'zuhr', 'asr'],
+    );
+
+    final snapshot = HomeScreenWidgetService.instance
+        .buildDailyPrayerTimesSnapshot(now: DateTime(2024, 6, 16));
+
+    expect(
+      namesFrom(snapshot),
+      ['Fajr', 'Sunrise', 'Zuhr', 'Asr', 'Sunset', 'Maghrib'],
+    );
+    expect(
+      snapshot[HomeScreenWidgetService.dailyPrayerTimeKeys[1]],
+      matches(RegExp(r'^\d{1,2}:\d{2} (am|pm)$')),
+    );
+  });
+
+  test('an unset selection falls back to the five prayers', () {
+    final snapshot = HomeScreenWidgetService.instance
+        .buildDailyPrayerTimesSnapshot(now: DateTime(2024, 6, 16));
+
+    expect(
+      namesFrom(snapshot),
+      ['Fajr', 'Zuhr', 'Asr', 'Maghrib', 'Isha'],
+    );
+  });
+
+  test('Up Next counts down to the selected times only', () async {
+    await saveWidgetPrayerTimes(['fajr', 'sunrise', 'sunset']);
+
+    final scheduled = scheduledNamesFrom(
+      HomeScreenWidgetService.instance.buildUpcomingPrayerSnapshot(),
+    );
+
+    expect(scheduled, {'Fajr', 'Sunrise', 'Sunset'});
+  });
+
+  test('a prayer still names its deadline when that marker is hidden',
+      () async {
+    await saveWidgetPrayerTimes(defaultWidgetPrayerTimeIds);
+
+    final schedule = (HomeScreenWidgetService.instance
+                .buildUpcomingPrayerSnapshot()[
+            HomeScreenWidgetService.prayerScheduleKey] ??
+        '');
+    final footers = {
+      for (final parts in schedule
+          .split(';')
+          .map((entry) => entry.split('|'))
+          .where((parts) => parts.length == 6))
+        parts[1]: parts[4],
+    };
+
+    expect(footers['Fajr'], 'Sunrise');
+    expect(footers['Zuhr'], 'Sunset');
+    expect(footers['Asr'], 'Sunset');
+    expect(footers['Maghrib'], 'Midnight');
+    expect(footers['Isha'], 'Midnight');
+  });
+
+  test('a daylight marker has no deadline of its own', () async {
+    await saveWidgetPrayerTimes(['sunrise', 'sunset', 'midnight']);
+
+    final schedule = (HomeScreenWidgetService.instance
+                .buildUpcomingPrayerSnapshot()[
+            HomeScreenWidgetService.prayerScheduleKey] ??
+        '');
+
+    for (final parts in schedule
+        .split(';')
+        .map((entry) => entry.split('|'))
+        .where((parts) => parts.length == 6)) {
+      expect(parts[4], isEmpty, reason: '${parts[1]} must not carry a footer');
+      expect(parts[5], isEmpty);
+    }
+  });
+
+  test('the widget never asks for more slots than it has', () {
+    expect(
+      HomeScreenWidgetService.dailyPrayerNameKeys.length,
+      maxWidgetPrayerTimes,
+    );
+    expect(
+      HomeScreenWidgetService.dailyPrayerTimeKeys.length,
+      maxWidgetPrayerTimes,
+    );
+  });
+}


### PR DESCRIPTION
Three changes to the home screen widgets, in two commits.

## 1. The countdown was not right-aligned on iOS

`Text(_:style: .timer)` reserves room for the widest value it can ever show and centres the digits inside that box, so aligning the box trailing left the countdown floating short of the edge. Splitting the header 50/50 between location and countdown made it worse — a long name plus a long timer overflowed its half and scaled down.

The countdown now takes its intrinsic width with `layoutPriority(1)` so the location fills what is left, and the timer text carries `multilineTextAlignment(.trailing)` of its own. Android was already correct: it renders a static `"Fajr in 2h 15m"` string with `TextAlign.End` and has no reserved-width behaviour.

## 2. The Next Prayer widget showed a date it did not need

The next prayer is always within a day, so the "Today"/"Tomorrow" line under the time carried no information. Removed, along with the plumbing that fed it on iOS, Android and the debug preview. The watch app still reads the same field, so the schedule encoding and `sc_prayer_date` are unchanged.

## 3. Settings picks which times the widgets show

The widgets were fixed to the five prayer starts, which is the wrong information for anyone offering a prayer before it becomes qaza — the deadline is Sunrise, Sunset or Midnight, and none of those appeared on the widget at all.

**Settings → Prayer & Location → Widget Prayer Times** now picks three to six entries out of Fajr, Sunrise, Zuhr, Asr, Sunset, Maghrib, Isha and Midnight. The default is the five prayers, so an existing install sees no change until it opts in. Fewer than three leaves the list widget looking broken and more than six stops the columns fitting a medium widget, so the dialog holds the selection between those bounds and an unreadable stored value falls back to the default rather than publishing an empty widget.

One selection drives both prayer widgets. The list widget renders it directly; the countdown widget advances through the same entries, which is why it is now called **Up Next** — it can count down to Sunrise, and calling that the next prayer would be wrong. The widget kind is unchanged, so existing placements survive. Its footer still names the deadline the current entry has to be offered before, resolved even when that marker is hidden from the list, so picking the plain five prayers still tells you when Fajr lapses.

`WidgetPrayerTime` is the single definition of what a time is, what it maps to in the prayer engine and what it must be offered before. The widget service reads that instead of hardcoding Fajr/Zuhr/Maghrib periods.

### Widening for a sixth slot

- `sc_daily_prayer_name_6` / `_time_6` on both platforms.
- `ios/Runner/AppDelegate.m` built the watch sync payload from a hardcoded five keys, so a six-time selection would have silently truncated on the watch. Widened along with `PrayerDataStore`.
- Column gutters tighten at six entries (8→4pt iOS, 4→2dp Android) and the time labels scale down further.
- Sunrise, Sunset and Midnight get their own icons — SF Symbols matching the mapping the watch app already used, plus three new vector drawables on Android.

## Testing

`test/widget_prayer_time_selection_test.dart` is new: the snapshot honouring a saved selection, the fallback when the stored value is unusable, the countdown targeting only selected times, and the deadline footers resolving for markers hidden from the list. `buildFiveDailyPrayerTimeEntries` is deleted, so its test is rewritten against `readWidgetPrayerTimes`, which also covers the daylight markers resolving in chronological order.

These were written but not executed locally — there is no Dart or Flutter toolchain in the environment this was authored in, so this PR's CI run is the first execution.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y8BXff47TXU95JFoVyV9W)_