### PR TITLE
Stop the geocode validator rejecting real city names

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -434,6 +434,10 @@ Future<bool> initializeLocation(
     await SP.prefs.setDouble("lat", lat!);
     await SP.prefs.setDouble("long", long!);
 
+    // The city label is cosmetic: prayer times are already correct at this
+    // point regardless of what the geocoder says. So every failure below leaves
+    // the previous label in place rather than degrading it — never coordinates,
+    // never a dialog.
     try {
       final response = await http.get(Uri.parse(
           "https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=$lat&longitude=$long&localityLanguage=en"));
@@ -441,36 +445,21 @@ Future<bool> initializeLocation(
         final data = jsonDecode(response.body);
         final resolvedCity =
             data['locality'] ?? data['city'] ?? data['principalSubdivision'];
-        final validCity = _validateGeocodeResult(data, resolvedCity);
-        if (validCity != null) {
-          city = validCity;
-          if (SP.prefs.getString("city") != city) needToSchedule = true;
-          if (city != null) await SP.prefs.setString("city", city!);
+        final resolvedLabel = _validateGeocodeResult(data, resolvedCity) ??
+            _validateGeocodeResult(data, _geocodeFallbackLabel(data));
+        if (resolvedLabel != null) {
+          if (city != resolvedLabel) needToSchedule = true;
+          city = resolvedLabel;
+          await SP.prefs.setString("city", resolvedLabel);
         } else {
           debugPrint(
-              "Geocode did not resolve a city name ('$resolvedCity'); using a broader location label.");
-          // Don't keep a stale previous city: reflect the new coordinates.
-          final fallback = _geocodeFallbackLabel(data, lat!, long!);
-          if (fallback != city) needToSchedule = true;
-          city = fallback;
-          await SP.prefs.setString("city", city!);
-          if (context != null && !kIsWeb) {
-            _showGeocodeFallbackDialog(context);
-          }
+              "Geocode did not resolve a usable label ('$resolvedCity'); keeping ${city ?? 'no label'}.");
         }
       } else {
         debugPrint("Geocode returned status ${response.statusCode}");
-        if (locationChanged) {
-          city = _geocodeFallbackLabel({}, lat!, long!);
-          await SP.prefs.setString("city", city!);
-        }
       }
     } catch (e) {
       debugPrint("Error getting city: $e");
-      if (locationChanged) {
-        city = _geocodeFallbackLabel({}, lat!, long!);
-        await SP.prefs.setString("city", city!);
-      }
     }
     if (locationChanged && flutterLocalNotificationsPlugin != null && !kIsWeb) {
       await setUpNotifications();
@@ -485,58 +474,49 @@ Future<bool> initializeLocation(
   }
 }
 
+/// Sanity-checks a reverse-geocode label before we show it.
+///
+/// The city name is display-only — prayer times are computed from lat/long, so
+/// this guards a label, not a calculation, and it stays deliberately loose. A
+/// two-letter `countryCode` means the coordinates landed in a real country,
+/// which is what rules out the ocean fixes emulators produce at (0, 0). Nothing
+/// more is required: demanding a populated `localityInfo.administrative` tree
+/// on top of that rejected perfectly good names in city-states and small
+/// territories, where the admin hierarchy is sparse.
 String? _validateGeocodeResult(
     Map<String, dynamic> data, String? resolvedCity) {
   if (resolvedCity == null || resolvedCity.trim().isEmpty) return null;
 
   final trimmed = resolvedCity.trim();
 
-  final countryCode = (data['countryCode'] ?? '').toString().trim().toUpperCase();
-  final hasCountryCode = countryCode.length == 2;
-  if (!hasCountryCode) return null;
+  final countryCode =
+      (data['countryCode'] ?? '').toString().trim().toUpperCase();
+  if (countryCode.length != 2) return null;
 
-  final localityInfo = data['localityInfo'];
-  if (localityInfo is Map) {
-    final administrative = localityInfo['administrative'];
-    if (administrative is List && administrative.isNotEmpty) {
-      final hasAdminArea = administrative.any((entry) {
-        if (entry is Map) {
-          // BigDataCloud reports admin level as `adminLevel` (2 = country,
-          // 4 = first-order subdivision). Older schemas used `level` '0'/'1'.
-          final level = entry['adminLevel'] ?? entry['level'];
-          final name = (entry['name'] ?? '').toString().trim();
-          final isCountryOrState =
-              level == 2 || level == 4 || level == '0' || level == '1';
-          if (isCountryOrState) return name.isNotEmpty;
-        }
-        return false;
-      });
-      if (!hasAdminArea) return null;
-    } else {
-      return null;
-    }
-  } else {
-    return null;
-  }
-
-  if (RegExp(r'^\d+\.?\d*\s*[ns]\s*\d+\.?\d*\s*[ew]$').hasMatch(trimmed)) {
+  if (RegExp(r'^\d+\.?\d*\s*[ns]\s*\d+\.?\d*\s*[ew]$', caseSensitive: false)
+      .hasMatch(trimmed)) {
     return null;
   }
 
   return trimmed;
 }
 
-/// Builds a readable location label from a geocode response when a precise
-/// city name can't be validated. Prefers the subdivision/country and falls
-/// back to raw coordinates so the UI never shows a stale previous location.
-String _geocodeFallbackLabel(Map<String, dynamic> data, double lat, double long) {
-  final candidate = (data['principalSubdivision'] ??
-      data['countryName'] ??
-      data['locality'] ??
-      '').toString().trim();
-  return candidate.isNotEmpty
-      ? candidate
-      : '${lat.toStringAsFixed(2)}, ${long.toStringAsFixed(2)}';
+/// Best readable label available from a geocode response when the primary
+/// locality can't be used. Widens from the city outwards and gives up rather
+/// than inventing something: returning null keeps whatever label we already
+/// had, because a stale city name reads better than raw coordinates — and this
+/// string is published to the home screen widget and watch complication.
+String? _geocodeFallbackLabel(Map<String, dynamic> data) {
+  for (final key in const [
+    'locality',
+    'city',
+    'principalSubdivision',
+    'countryName',
+  ]) {
+    final candidate = (data[key] ?? '').toString().trim();
+    if (candidate.isNotEmpty) return candidate;
+  }
+  return null;
 }
 
 void _showLocationServiceDialog(BuildContext context) {
@@ -560,27 +540,6 @@ void _showLocationServiceDialog(BuildContext context) {
               await Geolocator.openLocationSettings();
             },
             child: const Text('Open Settings'),
-          ),
-        ],
-      );
-    },
-  );
-}
-
-void _showGeocodeFallbackDialog(BuildContext context) {
-  showDialog(
-    context: context,
-    barrierDismissible: false,
-    builder: (BuildContext dialogContext) {
-      return AlertDialog(
-        title: const Text('Location Uncertain'),
-        content: const Text(
-          'We couldn\'t determine a precise city name for your current coordinates. Showing a broader location instead.',
-        ),
-        actions: [
-          ElevatedButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: const Text('OK'),
           ),
         ],
       );

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -445,10 +445,14 @@ Future<bool> initializeLocation(
 
     Position currentLocation;
     try {
+      // Medium accuracy is a network/wifi fix rather than a GPS lock: it
+      // returns in about a second instead of tens of seconds, and costs a
+      // fraction of the battery. The precision it gives up is irrelevant here —
+      // a few hundred metres moves any prayer time by well under a second.
       currentLocation = await Geolocator.getCurrentPosition(
         locationSettings: const LocationSettings(
-          accuracy: LocationAccuracy.high,
-          timeLimit: Duration(seconds: 20),
+          accuracy: LocationAccuracy.medium,
+          timeLimit: Duration(seconds: 10),
         ),
       );
     } on TimeoutException catch (e) {

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -138,8 +138,34 @@ Future<void> initializeNotificationTimeZone() async {
 String _scheduleDateKey(DateTime dateTime) =>
     dateTime.toIso8601String().substring(0, 10);
 
-String _scheduleLocationKey(double? value) =>
-    value == null ? 'unknown' : value.toStringAsFixed(4);
+/// How far the device must move, in degrees, before the notification schedule
+/// is worth rebuilding. Roughly 1 km, which shifts any prayer time by under two
+/// seconds.
+const double locationChangeThreshold = 0.01;
+
+const String _scheduleAnchorLatKey = 'prayer_schedule_anchor_lat';
+const String _scheduleAnchorLongKey = 'prayer_schedule_anchor_long';
+
+/// Whether we have moved far enough from the position the current notification
+/// schedule was built for to be worth rebuilding it.
+///
+/// Both callers — the check inside [initializeLocation] and
+/// [shouldRefreshPrayerNotificationSchedule] — go through here, against the
+/// same stored anchor, so they cannot disagree. Comparing against the anchor
+/// rather than against the previous reading is what stops jitter accumulating:
+/// a device wobbling either side of a boundary stays within the threshold of
+/// the anchor and never triggers a rebuild.
+bool hasPrayerScheduleLocationMoved() {
+  if (lat == null || long == null) return false;
+  if (!SP.isInitialized) return true;
+
+  final anchorLat = SP.prefs.getDouble(_scheduleAnchorLatKey);
+  final anchorLong = SP.prefs.getDouble(_scheduleAnchorLongKey);
+  if (anchorLat == null || anchorLong == null) return true;
+
+  return (anchorLat - lat!).abs() > locationChangeThreshold ||
+      (anchorLong - long!).abs() > locationChangeThreshold;
+}
 
 List<String> getPrayerNotificationPrayerNames() {
   return [
@@ -159,11 +185,13 @@ String buildPrayerNotificationScheduleFingerprint({DateTime? scheduleDate}) {
   final customAudioPath =
       azaanId == 'custom' ? SP.prefs.getString(azaanCustomFilePathKey) : null;
 
+  // Location is deliberately absent: it is tracked by the schedule anchor via
+  // hasPrayerScheduleLocationMoved(), which applies a distance threshold. Any
+  // rounding of raw coordinates into this string would flip on GPS jitter and
+  // force a full reschedule on the next app open.
   return [
-    'v6',
+    'v7',
     'date:${_scheduleDateKey(scheduleDate ?? DateTime.now())}',
-    'lat:${_scheduleLocationKey(lat)}',
-    'long:${_scheduleLocationKey(long)}',
     'tz:${tz.local.name}',
     'azaan:$azaanId',
     'custom:${customAudioPath ?? ''}',
@@ -201,6 +229,8 @@ bool shouldRefreshPrayerNotificationSchedule(
   }
 
   if (lat == null || long == null) return false;
+
+  if (hasPrayerScheduleLocationMoved()) return true;
 
   final prayerNames = getPrayerNotificationPrayerNames();
   if (!areAnyPrayerNotificationsEnabled(prayerNames)) return false;
@@ -420,14 +450,9 @@ Future<bool> initializeLocation(
         return false;
       }
     }
-    final previousLat = lat;
-    final previousLong = long;
     lat = currentLocation.latitude;
     long = currentLocation.longitude;
-    final locationChanged = previousLat == null ||
-        previousLong == null ||
-        (previousLat - lat!).abs() > 0.0001 ||
-        (previousLong - long!).abs() > 0.0001;
+    final locationChanged = hasPrayerScheduleLocationMoved();
     if (locationChanged) {
       needToSchedule = true;
     }
@@ -701,13 +726,14 @@ Future<void> setUpNotifications() async {
   if (lat == null || long == null) {
     debugPrint("Skipping Azan notifications: location unavailable");
     await SP.prefs.remove(prayerNotificationScheduleFingerprintKey);
+    await SP.prefs.remove(_scheduleAnchorLatKey);
+    await SP.prefs.remove(_scheduleAnchorLongKey);
     return;
   }
 
   if (enabledPrayerCount == 0) {
     debugPrint("Skipping Azan notifications: all prayers disabled");
-    await SP.prefs.setString(
-        prayerNotificationScheduleFingerprintKey, scheduleFingerprint);
+    await _storePrayerScheduleAnchor(scheduleFingerprint);
     return;
   }
 
@@ -749,8 +775,18 @@ Future<void> setUpNotifications() async {
       notificationDetails: platformChannelSpecifics,
       androidScheduleMode: AndroidScheduleMode.inexact,
       payload: now.add(Duration(days: scheduleDays - 1)).toIso8601String());
+  await _storePrayerScheduleAnchor(scheduleFingerprint);
+}
+
+/// Records what this schedule was built from: the fingerprint, and the position
+/// that future moves are measured against.
+Future<void> _storePrayerScheduleAnchor(String scheduleFingerprint) async {
   await SP.prefs
       .setString(prayerNotificationScheduleFingerprintKey, scheduleFingerprint);
+  if (lat != null && long != null) {
+    await SP.prefs.setDouble(_scheduleAnchorLatKey, lat!);
+    await SP.prefs.setDouble(_scheduleAnchorLongKey, long!);
+  }
 }
 
 /// Prepares custom audio file for notification playback

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -70,11 +70,6 @@ const String _androidPrayerChannelMigrationKey =
 const int _androidPrayerChannelMigrationVersion = 2;
 const String _androidPrayerChannelVersion = 'v2';
 
-bool shouldUseLiveLocation() {
-  if (!SP.isInitialized) return false;
-  return SP.prefs.getBool('use_live_location') ?? false;
-}
-
 /// Why the most recent [initializeLocation] gave up, so callers can say
 /// something more useful than "failed". Cleared on every success.
 enum LocationFailure {

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -75,6 +75,25 @@ bool shouldUseLiveLocation() {
   return SP.prefs.getBool('use_live_location') ?? false;
 }
 
+/// Why the most recent [initializeLocation] gave up, so callers can say
+/// something more useful than "failed". Cleared on every success.
+enum LocationFailure {
+  serviceDisabled,
+  permissionDenied,
+  permissionDeniedForever,
+  timeout,
+  unknown,
+}
+
+LocationFailure? lastLocationFailure;
+
+/// When the position behind the current [lat] / [long] was actually measured.
+///
+/// Not the same as when we fetched it: [initializeLocation] falls back to
+/// `getLastKnownPosition`, which can be hours or days old. Treating that as a
+/// fresh reading would let a caller believe it has an up-to-date fix.
+DateTime? lastLocationFixAt;
+
 bool shouldShowPrecisePrayerAlarmSetting({
   required TargetPlatform platform,
   bool isWeb = kIsWeb,
@@ -386,6 +405,7 @@ Future<bool> initializeLocation(
     final serviceEnabled = await Geolocator.isLocationServiceEnabled();
     if (!serviceEnabled) {
       debugPrint("Location service is disabled");
+      lastLocationFailure = LocationFailure.serviceDisabled;
       if (context != null && !kIsWeb) {
         _showLocationServiceDialog(context);
       }
@@ -401,6 +421,10 @@ Future<bool> initializeLocation(
         permissionStatus == LocationPermission.deniedForever ||
         permissionStatus == LocationPermission.unableToDetermine) {
       debugPrint("Location permission not granted: $permissionStatus");
+      lastLocationFailure =
+          permissionStatus == LocationPermission.deniedForever
+              ? LocationFailure.permissionDeniedForever
+              : LocationFailure.permissionDenied;
       if (context != null && !kIsWeb) {
         _showPermissionDeniedDialog(context, permissionStatus);
       }
@@ -433,6 +457,7 @@ Future<bool> initializeLocation(
         currentLocation = lastKnownPosition;
       } else {
         debugPrint("Location request timed out: $e");
+        lastLocationFailure = LocationFailure.timeout;
         if (context != null && !kIsWeb) {
           _showLocationTimeoutDialog(context);
         }
@@ -444,12 +469,19 @@ Future<bool> initializeLocation(
         currentLocation = lastKnownPosition;
       } else {
         debugPrint("Location fetch failed: $e");
+        lastLocationFailure = LocationFailure.unknown;
         if (context != null && !kIsWeb) {
           _showLocationErrorDialog(context, e);
         }
         return false;
       }
     }
+    lastLocationFailure = null;
+    // A device clock ahead of ours would otherwise make a fix look permanently
+    // fresh, so never accept a measurement timestamp from the future.
+    final nowForFix = DateTime.now();
+    final fixedAt = currentLocation.timestamp;
+    lastLocationFixAt = fixedAt.isAfter(nowForFix) ? nowForFix : fixedAt;
     lat = currentLocation.latitude;
     long = currentLocation.longitude;
     final locationChanged = hasPrayerScheduleLocationMoved();
@@ -492,6 +524,7 @@ Future<bool> initializeLocation(
     return true;
   } catch (e) {
     debugPrint(e.toString());
+    lastLocationFailure = LocationFailure.unknown;
     if (context != null && !kIsWeb) {
       _showLocationErrorDialog(context, e);
     }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -20,6 +20,7 @@ import 'package:shia_companion/pages/zikr/zikr_page.dart';
 import 'package:shia_companion/services/favorites_manager.dart';
 import 'package:shia_companion/services/home_screen_widget_service.dart';
 import 'package:shia_companion/services/library_service.dart';
+import 'package:shia_companion/services/location_service.dart';
 import 'package:shia_companion/services/qaza_tracker_manager.dart';
 import 'package:shia_companion/services/session_refresh_service.dart';
 import 'package:shia_companion/utils/data_search.dart';
@@ -59,7 +60,6 @@ class _MyHomePageState extends State<MyHomePage>
   DeepLinkTarget? _pendingDeepLink;
   bool _itemsLoaded = false;
   bool _isPublishingIndex = false;
-  bool _isRefreshingLiveLocation = false;
   String? _lastDeepLinkKey;
   DateTime? _lastDeepLinkAt;
   final CollectionReference<Map<String, dynamic>> _zikrCollection =
@@ -703,9 +703,12 @@ class _MyHomePageState extends State<MyHomePage>
     // On web, keep first load quiet and let the prayer card request location
     // only after the user taps it.
     if (!kIsWeb) {
-      await initializeLocation(
-        force: shouldUseLiveLocation(),
-        context: shouldUseLiveLocation() ? null : context,
+      // Pass context only when there is nothing stored yet: that first fetch
+      // needs the explainer and the permission prompt. Once a location exists,
+      // an automatic refresh must never interrupt the user with a dialog — the
+      // card shows the outcome instead.
+      await LocationService.instance.refreshIfStale(
+        context: LocationService.instance.hasLocation ? null : context,
       );
     }
 
@@ -745,23 +748,12 @@ class _MyHomePageState extends State<MyHomePage>
     setState(() {});
   }
 
-  Future<void> _refreshLiveLocationIfNeeded() async {
-    if (_isRefreshingLiveLocation ||
-        kIsWeb ||
-        !SP.isInitialized ||
-        !shouldUseLiveLocation()) {
-      return;
-    }
+  Future<void> _refreshLocationOnResume() async {
+    if (kIsWeb || !SP.isInitialized) return;
 
-    _isRefreshingLiveLocation = true;
-    final success = await initializeLocation(force: true);
-    _isRefreshingLiveLocation = false;
-
-    if (!mounted) return;
-    if (success) {
-      await HomeScreenWidgetService.instance.publishAll();
-      setState(() {});
-    }
+    // Cheap by design: this returns immediately unless the stored fix has aged
+    // past the freshness window, so flicking away and back costs nothing.
+    await LocationService.instance.refreshIfStale();
   }
 
   Future<void> _openSearch() async {
@@ -811,6 +803,7 @@ class _MyHomePageState extends State<MyHomePage>
     city = SP.prefs.getString("city");
     lat = SP.prefs.getDouble("lat");
     long = SP.prefs.getDouble("long");
+    LocationService.instance.restore();
     arabicFont = await FontPreferences.getSelectedFont() ?? "Qalam";
 
     // By default turn on Azan for Fajr, Dhuhr and Maghrib
@@ -943,7 +936,7 @@ class _MyHomePageState extends State<MyHomePage>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
-      _refreshLiveLocationIfNeeded();
+      _refreshLocationOnResume();
     }
   }
 

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -12,6 +12,7 @@ import '../constants.dart';
 import '../services/account_service.dart';
 import '../services/favorites_manager.dart';
 import '../services/home_screen_widget_service.dart';
+import '../services/location_service.dart';
 import '../services/qaza_tracker_manager.dart';
 import '../services/session_refresh_service.dart';
 import '../utils/dark_mode.dart';
@@ -49,9 +50,23 @@ class _SettingsPageState extends State<SettingsPage> {
   void initState() {
     super.initState();
     trackScreen('Settings Page');
+    // The refresh row reflects location status, which can also change from the
+    // home page or an automatic refresh, so follow the service rather than
+    // relying on this page's own taps to know when to redraw.
+    LocationService.instance.addListener(_onLocationChanged);
     if (_showPrecisePrayerAlarmSetting) {
       unawaited(_refreshExactAlarmPermissionStatus());
     }
+  }
+
+  @override
+  void dispose() {
+    LocationService.instance.removeListener(_onLocationChanged);
+    super.dispose();
+  }
+
+  void _onLocationChanged() {
+    if (mounted) setState(() {});
   }
 
   bool get _showPrecisePrayerAlarmSetting =>
@@ -82,32 +97,6 @@ class _SettingsPageState extends State<SettingsPage> {
                   adjustHijriAlertDialog(context);
                 },
               ),
-              SwitchListTile(
-                secondary: const Icon(Icons.my_location),
-                title: const Text("Always use live location"),
-                subtitle: Text(_liveLocationSubtitle()),
-                value: shouldUseLiveLocation(),
-                onChanged: (value) async {
-                  if (value) {
-                    final success = await initializeLocation(force: true);
-                    if (success) {
-                      await SP.prefs.setBool('use_live_location', true);
-                      await HomeScreenWidgetService.instance.publishAll();
-                    } else {
-                      await SP.prefs.setBool('use_live_location', false);
-                    }
-                    if (!mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                      content: Text(success
-                          ? "Live location enabled."
-                          : "Location permission was not granted."),
-                    ));
-                  } else {
-                    await SP.prefs.setBool('use_live_location', false);
-                  }
-                  setState(() {});
-                },
-              ),
               if (!kIsWeb)
                 ListTile(
                   leading: const Icon(Icons.widgets),
@@ -117,29 +106,41 @@ class _SettingsPageState extends State<SettingsPage> {
                     _showWidgetPrayerTimesDialog(context);
                   },
                 ),
-              if (!shouldUseLiveLocation())
-                ListTile(
-                  leading: const Icon(Icons.location_on),
-                  title: const Text("Refresh Location"),
-                  subtitle: Text(_refreshLocationSubtitle()),
-                  onTap: () async {
-                    bool success = await initializeLocation(force: true);
-                    if (success) {
-                      await HomeScreenWidgetService.instance.publishAll();
-                    }
-                    if (!mounted) return;
-                    if (success) {
-                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                        content: Text("Location has been refreshed."),
-                      ));
-                    } else {
-                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                        content: Text("Failed to refresh location."),
-                      ));
-                    }
-                    setState(() {});
-                  },
-                ),
+              ListTile(
+                leading: const Icon(Icons.location_on),
+                title: const Text("Refresh Location"),
+                subtitle: Text(_refreshLocationSubtitle()),
+                trailing: LocationService.instance.isRefreshing
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : null,
+                enabled: !LocationService.instance.isRefreshing,
+                onTap: () async {
+                  // Passing context lets initializeLocation explain *why* it
+                  // failed and offer the relevant settings screen, instead of
+                  // a snackbar that guesses. The row redraws from the service
+                  // listener, so there is no setState to sequence here.
+                  final success =
+                      await LocationService.instance.refresh(context: context);
+                  if (!mounted) return;
+                  if (success) {
+                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                      content: Text("Location has been refreshed."),
+                    ));
+                    return;
+                  }
+                  // Those diagnostic dialogs are all guarded on !kIsWeb, so on
+                  // web a failure would otherwise look like a dead tap.
+                  if (kIsWeb) {
+                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                      content: Text(LocationService.instance.failureMessage),
+                    ));
+                  }
+                },
+              ),
             ],
           ),
           if (!kIsWeb)
@@ -475,19 +476,35 @@ class _SettingsPageState extends State<SettingsPage> {
     return adjustment > 0 ? "$days $suffix ahead" : "$days $suffix behind";
   }
 
-  String _liveLocationSubtitle() {
-    if (shouldUseLiveLocation()) {
-      return "Prayer times will fetch your current location on app open.";
-    }
-    return "Reuse stored location until you refresh it manually.";
-  }
-
   String _refreshLocationSubtitle() {
+    final location = LocationService.instance;
+    if (location.isRefreshing) {
+      return "Updating your location…";
+    }
+    // Survives the snackbar, and covers the paths that show no dialog at all.
+    if (location.status == LocationRefreshStatus.failed) {
+      return "${location.failureMessage}. Tap to try again.";
+    }
+
     final savedCity = city?.trim();
-    if (savedCity != null && savedCity.isNotEmpty) {
+    if (savedCity == null || savedCity.isEmpty) {
+      return "Update the saved prayer-times location.";
+    }
+
+    final updatedAt = LocationService.instance.updatedAt;
+    if (updatedAt == null) {
       return "Current saved location: $savedCity.";
     }
-    return "Update the saved prayer-times location.";
+    return "$savedCity · updated ${_locationAgeLabel(updatedAt)}. "
+        "Refreshes on its own as you move.";
+  }
+
+  String _locationAgeLabel(DateTime updatedAt) {
+    final age = DateTime.now().difference(updatedAt);
+    if (age.inMinutes < 1) return "just now";
+    if (age.inMinutes < 60) return "${age.inMinutes}m ago";
+    if (age.inHours < 24) return "${age.inHours}h ago";
+    return "${age.inDays}d ago";
   }
 
   adjustHijriAlertDialog(BuildContext context) {

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,0 +1,231 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:shia_companion/constants.dart';
+import 'package:shia_companion/services/home_screen_widget_service.dart';
+import 'package:shia_companion/utils/shared_preferences.dart';
+
+/// What the location layer is doing right now, so the UI can say so.
+enum LocationRefreshStatus { idle, refreshing, failed }
+
+/// Owns *when* location is refreshed and *whether a refresh is in flight*.
+///
+/// The coordinates themselves still live in the `lat` / `long` / `city` globals
+/// that the notification scheduler, home screen widgets and watch complication
+/// all read; this sits on top and adds the three things they never modelled —
+/// freshness, in-flight status, and why the last attempt failed.
+///
+/// Refreshing is automatic. It used to be a user-facing "always use live
+/// location" switch, but the thing that setting was really protecting against
+/// was the cost of a GPS fix on every single app open, and a staleness window
+/// solves that without asking the user to understand the tradeoff. A location
+/// younger than [freshnessWindow] is simply reused.
+class LocationService extends ChangeNotifier {
+  LocationService._();
+
+  static final LocationService instance = LocationService._();
+
+  /// How long a fix is considered good enough to reuse. Long enough that
+  /// opening the app repeatedly costs nothing, short enough that a traveller
+  /// gets correct prayer times shortly after arriving.
+  static const Duration freshnessWindow = Duration(minutes: 30);
+
+  /// Past this we tell the user how old the reading is, because at that point
+  /// "these times might be for the wrong city" is a real possibility.
+  static const Duration staleDisclosureAge = Duration(hours: 6);
+
+  /// How long an automatic refresh backs off after a failure. A device that
+  /// cannot produce a fix at all — permission denied, location services off —
+  /// is permanently stale, so without this it would run a full attempt on every
+  /// single resume. Successful fetches need no cooldown; [freshnessWindow]
+  /// already paces those.
+  static const Duration retryCooldown = Duration(minutes: 2);
+
+  static const String updatedAtKey = 'location_updated_at';
+  static const String _legacyLiveLocationKey = 'use_live_location';
+
+  LocationRefreshStatus _status = LocationRefreshStatus.idle;
+  DateTime? _updatedAt;
+  DateTime? _lastUnproductiveAttemptAt;
+  Future<bool>? _inFlight;
+
+  LocationRefreshStatus get status => _status;
+
+  bool get isRefreshing => _status == LocationRefreshStatus.refreshing;
+
+  /// Non-null only while [status] is [LocationRefreshStatus.failed].
+  LocationFailure? get failure =>
+      _status == LocationRefreshStatus.failed ? lastLocationFailure : null;
+
+  bool get hasLocation => lat != null && long != null;
+
+  DateTime? get updatedAt => _updatedAt;
+
+  /// Whether a fresh reading is worth fetching. No stored location always
+  /// qualifies, so first run fetches immediately.
+  bool get isStale {
+    if (!hasLocation) return true;
+    final updatedAt = _updatedAt;
+    if (updatedAt == null) return true;
+    return DateTime.now().difference(updatedAt) >= freshnessWindow;
+  }
+
+  /// Whether the reading is old enough that the UI should admit its age.
+  bool get shouldDiscloseAge {
+    final updatedAt = _updatedAt;
+    if (!hasLocation || updatedAt == null) return false;
+    return DateTime.now().difference(updatedAt) >= staleDisclosureAge;
+  }
+
+  /// Loads the persisted freshness stamp. Call after [SP.init] and after the
+  /// `lat` / `long` / `city` globals have been restored.
+  void restore() {
+    if (!SP.isInitialized) return;
+
+    final storedMillis = SP.prefs.getInt(updatedAtKey);
+    if (storedMillis != null) {
+      _updatedAt = DateTime.fromMillisecondsSinceEpoch(storedMillis);
+    } else if (hasLocation) {
+      // Upgrading from a build that never recorded this. Treat the stored fix
+      // as stale so the next open refreshes it once and starts the clock.
+      _updatedAt = null;
+    }
+
+    // The "always use live location" switch this service replaces.
+    if (SP.prefs.containsKey(_legacyLiveLocationKey)) {
+      unawaited(SP.prefs.remove(_legacyLiveLocationKey));
+    }
+  }
+
+  /// Refreshes only if the current reading has aged out. Safe to call on every
+  /// app open and every resume — that is the point of it.
+  Future<bool> refreshIfStale({BuildContext? context}) {
+    if (!isStale) {
+      // The stored fix is good enough, so any error still on display is about
+      // an attempt we have since decided we did not need. Clearing it stops a
+      // one-off failure pinning a red message on the card for half an hour —
+      // but not on top of a running fetch, whose spinner would vanish.
+      if (_inFlight == null) _setStatus(LocationRefreshStatus.idle);
+      return Future.value(true);
+    }
+
+    // Back off from an attempt that got us nowhere, but never while one is
+    // already running: an overlapping caller should join the in-flight fetch
+    // rather than be turned away.
+    final lastUnproductiveAttemptAt = _lastUnproductiveAttemptAt;
+    if (_inFlight == null &&
+        lastUnproductiveAttemptAt != null &&
+        DateTime.now().difference(lastUnproductiveAttemptAt) < retryCooldown) {
+      return Future.value(hasLocation);
+    }
+
+    return refresh(context: context);
+  }
+
+  /// Fetches a new position.
+  ///
+  /// Concurrent callers share one fetch: app open, resume and a button tap can
+  /// overlap, and running them in parallel would race on the globals and
+  /// schedule notifications twice.
+  ///
+  /// [context] opts into the blocking diagnostic dialogs (services off,
+  /// permission denied, timeout). Pass it for refreshes the user asked for;
+  /// leave it null for automatic ones, where [status] carries the failure into
+  /// the UI instead of interrupting them.
+  Future<bool> refresh({BuildContext? context}) {
+    final inFlight = _inFlight;
+    if (inFlight != null) return inFlight;
+
+    _setStatus(LocationRefreshStatus.refreshing);
+    // whenComplete resolves a microtask after _run finishes, so the assignment
+    // below always lands first and every overlapping caller sees this future.
+    final fetch = _run(context: context).whenComplete(() => _inFlight = null);
+    _inFlight = fetch;
+    return fetch;
+  }
+
+  Future<bool> _run({BuildContext? context}) async {
+    // First run has no stored location and no explainer shown yet, so let
+    // initializeLocation walk the user through it rather than forcing.
+    final isFirstEverFetch = !hasLocation;
+
+    bool success;
+    try {
+      success = await initializeLocation(
+        force: !isFirstEverFetch,
+        context: context,
+      );
+    } catch (e) {
+      debugPrint('Location refresh failed: $e');
+      lastLocationFailure = LocationFailure.unknown;
+      _lastUnproductiveAttemptAt = DateTime.now();
+      _setStatus(LocationRefreshStatus.failed);
+      return false;
+    }
+
+    // Deliberately outside the try above. By this point the coordinates are
+    // already updated and prayer times are already correct, so a failure to
+    // persist the stamp or repaint a home screen widget is not a location
+    // failure and must not be reported as one.
+    if (success) {
+      // How old the reading is, not when we asked for it: initializeLocation
+      // may have fallen back to a much older last-known position.
+      _updatedAt = lastLocationFixAt ?? DateTime.now();
+      try {
+        if (SP.isInitialized) {
+          await SP.prefs
+              .setInt(updatedAtKey, _updatedAt!.millisecondsSinceEpoch);
+        }
+        await HomeScreenWidgetService.instance.publishAll();
+      } catch (e) {
+        debugPrint('Location stored, but publishing it failed: $e');
+      }
+    }
+
+    // Back off from anything that left us no better off. A failure obviously
+    // qualifies, but so does a success that only recovered a stale last-known
+    // position: we are still stale, and without this every resume would run
+    // another full attempt trying to improve on it.
+    _lastUnproductiveAttemptAt = success && !isStale ? null : DateTime.now();
+
+    _setStatus(
+      success ? LocationRefreshStatus.idle : LocationRefreshStatus.failed,
+    );
+    return success;
+  }
+
+  void _setStatus(LocationRefreshStatus status) {
+    if (_status == status) return;
+    _status = status;
+    notifyListeners();
+  }
+
+  /// A short reason for the most recent failure, for inline display.
+  String get failureMessage {
+    switch (failure) {
+      case LocationFailure.serviceDisabled:
+        return 'Location services are off';
+      case LocationFailure.permissionDenied:
+      case LocationFailure.permissionDeniedForever:
+        return 'Location permission needed';
+      case LocationFailure.timeout:
+        return "Couldn't get a location fix";
+      case LocationFailure.unknown:
+      case null:
+        return "Couldn't update location";
+    }
+  }
+
+  @visibleForTesting
+  void resetForTest() {
+    _status = LocationRefreshStatus.idle;
+    _updatedAt = null;
+    _lastUnproductiveAttemptAt = null;
+    _inFlight = null;
+  }
+
+  @visibleForTesting
+  void setUpdatedAtForTest(DateTime? value) {
+    _updatedAt = value;
+  }
+}

--- a/lib/widgets/prayer_times_widget.dart
+++ b/lib/widgets/prayer_times_widget.dart
@@ -1,7 +1,6 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hijri/hijri_calendar.dart';
-import 'package:shia_companion/services/home_screen_widget_service.dart';
+import 'package:shia_companion/services/location_service.dart';
 import 'package:shia_companion/utils/prayer_times.dart';
 import '../constants.dart';
 
@@ -15,6 +14,31 @@ class HomePrayerTimesCard extends StatefulWidget {
 class PrayerTimesState extends State<HomePrayerTimesCard> {
   PrayerTimesState();
 
+  final LocationService _location = LocationService.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    _location.addListener(_onLocationChanged);
+  }
+
+  @override
+  void dispose() {
+    _location.removeListener(_onLocationChanged);
+    super.dispose();
+  }
+
+  void _onLocationChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _refreshLocation() async {
+    // Explicit user action, so pass context: this is the one moment where an
+    // interrupting dialog about permissions or location services is welcome.
+    await _location.refresh(context: context);
+    if (mounted) setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     DateTime currentTime = DateTime.now();
@@ -22,9 +46,9 @@ class PrayerTimesState extends State<HomePrayerTimesCard> {
         HijriCalendar.fromDate(DateTime.now().add(Duration(days: hijriDate)));
     PrayerTime prayerTime = getPrayerTimeObject();
     prayerTime.setTimeFormat(prayerTime.getTime12());
-    final useLiveLocation = shouldUseLiveLocation();
-    final isFetchingLiveLocation = useLiveLocation && !kIsWeb;
 
+    // Always render from the last known fix. A refresh in flight, or one that
+    // just failed, never blanks times the user could still be relying on.
     List<String>? _prayerTimes = lat != null
         ? prayerTime.getPrayerTimes(currentTime, lat!, long!,
             currentTime.timeZoneOffset.inMinutes / 60.0)
@@ -47,48 +71,10 @@ class PrayerTimesState extends State<HomePrayerTimesCard> {
                     mainAxisSize: MainAxisSize.min,
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      city != null
-                          ? Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Flexible(
-                                  child: Text(
-                                    "Location: $city",
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
-                                if (!useLiveLocation)
-                                  InkWell(
-                                    onTap: () async {
-                                      bool success =
-                                          await initializeLocation(force: true);
-                                      if (success) {
-                                        await HomeScreenWidgetService.instance
-                                            .publishAll();
-                                      }
-                                      if (mounted) {
-                                        setState(() {});
-                                        if (success) {
-                                          ScaffoldMessenger.of(context)
-                                              .showSnackBar(SnackBar(
-                                                  content: Text(
-                                                      "Location updated")));
-                                        } else {
-                                          ScaffoldMessenger.of(context)
-                                              .showSnackBar(SnackBar(
-                                                  content: Text(
-                                                      "Failed to update location")));
-                                        }
-                                      }
-                                    },
-                                    child: Padding(
-                                      padding: const EdgeInsets.all(4.0),
-                                      child: Icon(Icons.refresh, size: 18),
-                                    ),
-                                  ),
-                              ],
-                            )
-                          : Container(),
+                      _LocationStatusRow(
+                        location: _location,
+                        onRefresh: _refreshLocation,
+                      ),
                       SizedBox(
                         height: 4,
                       ),
@@ -135,54 +121,175 @@ class PrayerTimesState extends State<HomePrayerTimesCard> {
                       ),
                     ],
                   )
-                : InkWell(
-                    onTap: () async {
-                      if (isFetchingLiveLocation) return;
-                      final success = await initializeLocation(
-                        force: true,
-                        context: context,
-                      );
-                      if (success) {
-                        await HomeScreenWidgetService.instance.publishAll();
-                      }
-                      if (mounted) setState(() {});
-                    },
-                    child: Container(
-                      width: double.infinity,
-                      padding: const EdgeInsets.all(24.0),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            isFetchingLiveLocation
-                                ? Icons.location_searching
-                                : Icons.location_off,
-                            size: 40,
-                            color: Theme.of(context).colorScheme.primary,
-                          ),
-                          const SizedBox(height: 12),
-                          Text(
-                            isFetchingLiveLocation
-                                ? "Fetching live location to display prayer times"
-                                : "Location not available",
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context).textTheme.bodyMedium,
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            isFetchingLiveLocation
-                                ? "Please wait..."
-                                : "Tap here to enable location",
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context).textTheme.bodySmall,
-                          ),
-                        ],
-                      ),
-                    ),
+                : _LocationEmptyState(
+                    location: _location,
+                    onRefresh: _refreshLocation,
                   ),
           ],
         ),
       ),
     );
   }
+}
+
+/// The one line above the times that carries every location state: which city
+/// the times belong to, whether a refresh is running, how old the fix is, and
+/// what went wrong last time. Deliberately the only thing that changes — the
+/// prayer times below it never move.
+class _LocationStatusRow extends StatelessWidget {
+  const _LocationStatusRow({
+    required this.location,
+    required this.onRefresh,
+  });
+
+  final LocationService location;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final failed = location.status == LocationRefreshStatus.failed;
+    final label = city;
+
+    final String text;
+    if (failed) {
+      text = label == null
+          ? location.failureMessage
+          : "$label · ${location.failureMessage}";
+    } else if (label == null) {
+      // A missing label does not mean a missing location: this row only renders
+      // once there are coordinates, and the geocode that names them is allowed
+      // to fail on its own. Only claim to be locating if we actually are.
+      text = location.isRefreshing
+          ? "Locating…"
+          : "Prayer times for your location";
+    } else if (location.shouldDiscloseAge) {
+      text = "Location: $label · updated ${_ageLabel(location.updatedAt!)}";
+    } else {
+      text = "Location: $label";
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Flexible(
+          child: Text(
+            text,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: failed
+                ? theme.textTheme.bodyMedium?.copyWith(color: colorScheme.error)
+                : null,
+          ),
+        ),
+        // The refresh affordance is always present, whatever the state — a
+        // failed location must never be a dead end.
+        location.isRefreshing
+            ? const Padding(
+                padding: EdgeInsets.all(4.0),
+                child: SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              )
+            : InkWell(
+                onTap: onRefresh,
+                child: Padding(
+                  padding: const EdgeInsets.all(4.0),
+                  child: Icon(
+                    Icons.refresh,
+                    size: 18,
+                    color: failed ? colorScheme.error : null,
+                  ),
+                ),
+              ),
+      ],
+    );
+  }
+}
+
+/// Shown only when no location has ever been resolved, so there are no times to
+/// protect. Always tappable — including while a fetch is running, because a
+/// fetch that silently died must not strand the user on a spinner.
+class _LocationEmptyState extends StatelessWidget {
+  const _LocationEmptyState({
+    required this.location,
+    required this.onRefresh,
+  });
+
+  final LocationService location;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final refreshing = location.isRefreshing;
+    final failed = location.status == LocationRefreshStatus.failed;
+
+    final String title;
+    final String subtitle;
+    if (refreshing) {
+      title = "Finding your location";
+      subtitle = "Prayer times will appear in a moment";
+    } else if (failed) {
+      title = location.failureMessage;
+      subtitle = "Tap to try again";
+    } else {
+      title = "Location not available";
+      subtitle = "Tap here to enable location";
+    }
+
+    return InkWell(
+      onTap: onRefresh,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            refreshing
+                ? const SizedBox(
+                    width: 40,
+                    height: 40,
+                    child: Padding(
+                      padding: EdgeInsets.all(4.0),
+                      child: CircularProgressIndicator(strokeWidth: 3),
+                    ),
+                  )
+                : Icon(
+                    failed ? Icons.location_disabled : Icons.location_off,
+                    size: 40,
+                    color: failed
+                        ? theme.colorScheme.error
+                        : theme.colorScheme.primary,
+                  ),
+            const SizedBox(height: 12),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: failed ? theme.colorScheme.error : null,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              subtitle,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _ageLabel(DateTime updatedAt) {
+  final age = DateTime.now().difference(updatedAt);
+  if (age.inDays >= 1) {
+    return "${age.inDays}d ago";
+  }
+  return "${age.inHours}h ago";
 }

--- a/test/location_fetch_test.dart
+++ b/test/location_fetch_test.dart
@@ -164,31 +164,91 @@ void main() {
       );
     });
 
-    test('replaces a stale city with a broader label when validation fails',
+    test('keeps a sparse administrative tree from rejecting a real city',
         () async {
       city = 'Old City';
+      GeolocatorPlatform.instance = _FakeGeolocator(
+        currentPosition: _pos(26.22, 50.58),
+      );
+
+      // City-states and small territories report a shallow admin hierarchy with
+      // no country/subdivision entry. The locality is still the right label.
+      await runWithGeocode(
+        '{"locality":"Manama","city":"Manama",'
+        '"principalSubdivision":"Capital","countryName":"Bahrain",'
+        '"countryCode":"BH","localityInfo":{"administrative":'
+        '[{"adminLevel":8,"name":"Manama"}]}}',
+        body: () async {
+          final success = await initializeLocation(force: true);
+
+          expect(success, isTrue);
+          expect(city, 'Manama');
+        },
+      );
+    });
+
+    test('widens to the next available label when there is no locality',
+        () async {
       GeolocatorPlatform.instance = _FakeGeolocator(
         currentPosition: _pos(1.0, 2.0),
       );
 
-      // Missing administrative area -> _validateGeocodeResult rejects the city.
       await runWithGeocode(
-        '{"locality":"Somewhere","city":"Somewhere",'
+        '{"locality":"","city":"",'
         '"principalSubdivision":"Region X","countryName":"Country Y",'
-        '"countryCode":"US","localityInfo":{"administrative":'
-        '[{"adminLevel":8,"name":"Somewhere"}]}}',
+        '"countryCode":"US","localityInfo":{"administrative":[]}}',
         body: () async {
           final success = await initializeLocation(force: true);
 
           expect(success, isTrue);
           expect(city, 'Region X');
-          expect(city, isNot('Old City'));
         },
       );
     });
 
-    test('falls back to coordinates when the geocode request fails',
+    test('rejects an ocean fix with no country code', () async {
+      city = 'Old City';
+      GeolocatorPlatform.instance = _FakeGeolocator(
+        currentPosition: _pos(0.0, 0.0),
+      );
+
+      // What an emulator parked at Null Island returns: a plausible-looking
+      // ocean name, but no country. The previous label must survive.
+      await runWithGeocode(
+        '{"locality":"Atlantic Ocean","city":"",'
+        '"principalSubdivision":"","countryName":"",'
+        '"countryCode":"","localityInfo":{"administrative":[]}}',
+        body: () async {
+          final success = await initializeLocation(force: true);
+
+          expect(success, isTrue);
+          expect(city, 'Old City');
+        },
+      );
+    });
+
+    test('never degrades the saved city to coordinates when geocode fails',
         () async {
+      city = 'Stable City';
+      GeolocatorPlatform.instance = _FakeGeolocator(
+        currentPosition: _pos(3.0, 4.0),
+      );
+
+      // This label is published to the home screen widget and the watch
+      // complication, so a transient network failure must not rewrite it.
+      await runWithGeocode(
+        null,
+        geocodeError: Exception('no network'),
+        body: () async {
+          final success = await initializeLocation(force: true);
+
+          expect(success, isTrue);
+          expect(city, 'Stable City');
+        },
+      );
+    });
+
+    test('leaves the city unset when the first ever geocode fails', () async {
       GeolocatorPlatform.instance = _FakeGeolocator(
         currentPosition: _pos(3.0, 4.0),
       );
@@ -200,28 +260,8 @@ void main() {
           final success = await initializeLocation(force: true);
 
           expect(success, isTrue);
-          expect(city, startsWith('3.00'));
-        },
-      );
-    });
-
-    test('keeps the previous city when nothing moved and geocode fails',
-        () async {
-      city = 'Stable City';
-      lat = 10.0;
-      long = 20.0;
-      GeolocatorPlatform.instance = _FakeGeolocator(
-        currentPosition: _pos(10.00001, 20.00001),
-      );
-
-      await runWithGeocode(
-        null,
-        geocodeError: Exception('no network'),
-        body: () async {
-          final success = await initializeLocation(force: true);
-
-          expect(success, isTrue);
-          expect(city, 'Stable City');
+          expect(lat, 3.0);
+          expect(city, isNull);
         },
       );
     });

--- a/test/location_fetch_test.dart
+++ b/test/location_fetch_test.dart
@@ -23,7 +23,7 @@ void main() {
   Position _pos(double latitude, double longitude) => Position(
         latitude: latitude,
         longitude: longitude,
-        timestamp: DateTime(2020, 1, 1),
+        timestamp: DateTime.now(),
         accuracy: 1,
         altitude: 0,
         altitudeAccuracy: 1,

--- a/test/location_service_test.dart
+++ b/test/location_service_test.dart
@@ -1,0 +1,410 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shia_companion/constants.dart';
+import 'package:shia_companion/services/location_service.dart';
+import 'package:shia_companion/utils/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final service = LocationService.instance;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SP.init();
+    lat = null;
+    long = null;
+    city = null;
+    needToSchedule = false;
+    lastLocationFailure = null;
+    service.resetForTest();
+  });
+
+  Position _posAt(double latitude, double longitude, DateTime timestamp) =>
+      Position(
+        latitude: latitude,
+        longitude: longitude,
+        timestamp: timestamp,
+        accuracy: 1,
+        altitude: 0,
+        altitudeAccuracy: 1,
+        heading: 0,
+        headingAccuracy: 1,
+        speed: 0,
+        speedAccuracy: 1,
+      );
+
+  Position _pos(double latitude, double longitude) =>
+      _posAt(latitude, longitude, DateTime.now());
+
+  Future<T> withGeocode<T>(Future<T> Function() body) {
+    return http.runWithClient(
+      body,
+      () => MockClient((request) async => http.Response(
+            '{"locality":"Karbala","city":"Karbala",'
+            '"principalSubdivision":"Karbala","countryName":"Iraq",'
+            '"countryCode":"IQ"}',
+            200,
+          )),
+    );
+  }
+
+  group('freshness window', () {
+    test('reuses a recent fix instead of fetching again', () async {
+      final geolocator = _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() async {
+        await service.refresh();
+        expect(geolocator.currentPositionCalls, 1);
+
+        // Second open, moments later: nothing should hit the location stack.
+        final reused = await service.refreshIfStale();
+
+        expect(reused, isTrue);
+        expect(geolocator.currentPositionCalls, 1);
+      });
+    });
+
+    test('refetches once the fix has aged out', () async {
+      final geolocator = _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() async {
+        await service.refresh();
+        expect(geolocator.currentPositionCalls, 1);
+
+        service.setUpdatedAtForTest(
+          DateTime.now().subtract(LocationService.freshnessWindow * 2),
+        );
+
+        await service.refreshIfStale();
+
+        expect(geolocator.currentPositionCalls, 2);
+      });
+    });
+
+    test('always fetches when nothing is stored yet', () async {
+      final geolocator = _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      GeolocatorPlatform.instance = geolocator;
+
+      expect(service.isStale, isTrue);
+
+      await withGeocode(() async {
+        await service.refreshIfStale();
+        expect(geolocator.currentPositionCalls, 1);
+      });
+    });
+
+    test('an explicit refresh ignores the freshness window', () async {
+      final geolocator = _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() async {
+        await service.refresh();
+        expect(service.isStale, isFalse);
+
+        await service.refresh();
+
+        expect(geolocator.currentPositionCalls, 2);
+      });
+    });
+  });
+
+  group('stale fixes and retry cooldown', () {
+    test('ages a last-known fallback from when it was measured', () async {
+      final old = DateTime.now().subtract(const Duration(hours: 20));
+      GeolocatorPlatform.instance = _CountingGeolocator(
+        currentPositionError: TimeoutException('no fix'),
+        lastKnownPosition: _posAt(32.6, 44.0, old),
+      );
+
+      await withGeocode(() => service.refresh());
+
+      // Stamping this "now" would hide a 20-hour-old fix behind a fresh label
+      // and block a retry for the whole freshness window.
+      expect(service.updatedAt, old);
+      expect(service.isStale, isTrue);
+      expect(service.shouldDiscloseAge, isTrue);
+    });
+
+    test('does not retry every resume when only a stale fallback is available',
+        () async {
+      final geolocator = _CountingGeolocator(
+        currentPositionError: TimeoutException('no fix'),
+        lastKnownPosition:
+            _posAt(32.6, 44.0, DateTime.now().subtract(const Duration(days: 1))),
+      );
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() => service.refreshIfStale());
+      expect(geolocator.currentPositionCalls, 1);
+
+      // The fetch "succeeded", but only by recovering a day-old fix, so we are
+      // still stale and would otherwise attempt again on every single resume.
+      expect(service.isStale, isTrue);
+      await withGeocode(() => service.refreshIfStale());
+      await withGeocode(() => service.refreshIfStale());
+
+      expect(geolocator.currentPositionCalls, 1);
+    });
+
+    test('does not retry an unfixable device on every resume', () async {
+      final geolocator = _CountingGeolocator(serviceEnabled: false);
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() => service.refreshIfStale());
+      expect(geolocator.currentPositionCalls, 0);
+
+      // Location is permanently stale here, so without a cooldown each of
+      // these would run a full attempt.
+      await withGeocode(() => service.refreshIfStale());
+      await withGeocode(() => service.refreshIfStale());
+
+      expect(geolocator.isLocationServiceEnabledCalls, 1);
+    });
+
+    test('an explicit refresh ignores the cooldown', () async {
+      final geolocator = _CountingGeolocator(serviceEnabled: false);
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() => service.refreshIfStale());
+      await withGeocode(() => service.refresh());
+
+      expect(geolocator.isLocationServiceEnabledCalls, 2);
+    });
+
+    test('drops a failure once the stored fix is deemed good enough', () async {
+      GeolocatorPlatform.instance =
+          _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      await withGeocode(() => service.refresh());
+
+      GeolocatorPlatform.instance = _CountingGeolocator(serviceEnabled: false);
+      await withGeocode(() => service.refresh());
+      expect(service.status, LocationRefreshStatus.failed);
+
+      // Next open: the fix is still fresh, so we are not retrying and have no
+      // business showing a red error about an attempt we no longer need.
+      await withGeocode(() => service.refreshIfStale());
+
+      expect(service.status, LocationRefreshStatus.idle);
+    });
+  });
+
+  group('in-flight dedupe', () {
+    test('overlapping callers share a single fetch', () async {
+      final gate = Completer<Position>();
+      final geolocator = _CountingGeolocator(pending: gate.future);
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() async {
+        // App open, resume and a button tap landing together.
+        final first = service.refresh();
+        final second = service.refresh();
+        final third = service.refreshIfStale();
+
+        expect(service.isRefreshing, isTrue);
+        gate.complete(_pos(32.6, 44.0));
+
+        expect(await Future.wait([first, second, third]),
+            [isTrue, isTrue, isTrue]);
+        expect(geolocator.currentPositionCalls, 1);
+      });
+    });
+
+    test('a new fetch is allowed once the previous one settles', () async {
+      final geolocator = _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      GeolocatorPlatform.instance = geolocator;
+
+      await withGeocode(() async {
+        await service.refresh();
+        await service.refresh();
+
+        expect(geolocator.currentPositionCalls, 2);
+      });
+    });
+  });
+
+  group('status', () {
+    test('reports refreshing then idle across a successful fetch', () async {
+      final gate = Completer<Position>();
+      GeolocatorPlatform.instance = _CountingGeolocator(pending: gate.future);
+
+      final seen = <LocationRefreshStatus>[];
+      void listener() => seen.add(service.status);
+      service.addListener(listener);
+      addTearDown(() => service.removeListener(listener));
+
+      await withGeocode(() async {
+        final fetch = service.refresh();
+        expect(service.status, LocationRefreshStatus.refreshing);
+
+        gate.complete(_pos(32.6, 44.0));
+        await fetch;
+      });
+
+      expect(service.status, LocationRefreshStatus.idle);
+      expect(seen,
+          [LocationRefreshStatus.refreshing, LocationRefreshStatus.idle]);
+    });
+
+    test('surfaces why a fetch failed instead of just failing', () async {
+      GeolocatorPlatform.instance = _CountingGeolocator(serviceEnabled: false);
+
+      final success = await withGeocode(() => service.refresh());
+
+      expect(success, isFalse);
+      expect(service.status, LocationRefreshStatus.failed);
+      expect(service.failure, LocationFailure.serviceDisabled);
+      expect(service.failureMessage, 'Location services are off');
+    });
+
+    test('distinguishes a permanent permission denial', () async {
+      GeolocatorPlatform.instance = _CountingGeolocator(
+        permission: LocationPermission.deniedForever,
+      );
+
+      await withGeocode(() => service.refresh());
+
+      expect(service.failure, LocationFailure.permissionDeniedForever);
+    });
+
+    test('a failed fetch leaves the previous location intact', () async {
+      final geolocator = _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      GeolocatorPlatform.instance = geolocator;
+      await withGeocode(() => service.refresh());
+
+      GeolocatorPlatform.instance = _CountingGeolocator(serviceEnabled: false);
+      await withGeocode(() => service.refresh());
+
+      // The card keeps rendering prayer times from these.
+      expect(lat, 32.6);
+      expect(long, 44.0);
+      expect(city, 'Karbala');
+    });
+
+    test('clears a stale failure after a later success', () async {
+      GeolocatorPlatform.instance = _CountingGeolocator(serviceEnabled: false);
+      await withGeocode(() => service.refresh());
+      expect(service.failure, isNotNull);
+
+      GeolocatorPlatform.instance =
+          _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      await withGeocode(() => service.refresh());
+
+      expect(service.status, LocationRefreshStatus.idle);
+      expect(service.failure, isNull);
+    });
+  });
+
+  group('restore', () {
+    test('treats a location stored without a stamp as stale', () async {
+      lat = 32.6;
+      long = 44.0;
+
+      service.restore();
+
+      expect(service.updatedAt, isNull);
+      expect(service.isStale, isTrue);
+    });
+
+    test('reads back a persisted stamp so a restart stays throttled', () async {
+      final geolocator = _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      GeolocatorPlatform.instance = geolocator;
+      await withGeocode(() => service.refresh());
+
+      // Simulate a cold start with the same prefs.
+      service.resetForTest();
+      service.restore();
+
+      expect(service.updatedAt, isNotNull);
+      expect(service.isStale, isFalse);
+      await service.refreshIfStale();
+      expect(geolocator.currentPositionCalls, 1);
+    });
+
+    test('drops the retired live-location switch', () async {
+      await SP.prefs.setBool('use_live_location', true);
+
+      service.restore();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(SP.prefs.containsKey('use_live_location'), isFalse);
+    });
+  });
+
+  group('age disclosure', () {
+    test('stays quiet about a fresh reading', () async {
+      GeolocatorPlatform.instance =
+          _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      await withGeocode(() => service.refresh());
+
+      expect(service.shouldDiscloseAge, isFalse);
+    });
+
+    test('admits the age once the reading is old', () async {
+      GeolocatorPlatform.instance =
+          _CountingGeolocator(currentPosition: _pos(32.6, 44.0));
+      await withGeocode(() => service.refresh());
+
+      service.setUpdatedAtForTest(
+        DateTime.now().subtract(LocationService.staleDisclosureAge * 2),
+      );
+
+      expect(service.shouldDiscloseAge, isTrue);
+    });
+  });
+}
+
+class _CountingGeolocator extends GeolocatorPlatform {
+  _CountingGeolocator({
+    this.currentPosition,
+    this.currentPositionError,
+    this.lastKnownPosition,
+    this.pending,
+    this.serviceEnabled = true,
+    this.permission = LocationPermission.always,
+  });
+
+  final Position? currentPosition;
+  final Object? currentPositionError;
+  final Position? lastKnownPosition;
+  final Future<Position>? pending;
+  final bool serviceEnabled;
+  final LocationPermission permission;
+
+  int currentPositionCalls = 0;
+  int isLocationServiceEnabledCalls = 0;
+
+  @override
+  Future<bool> isLocationServiceEnabled() {
+    isLocationServiceEnabledCalls++;
+    return Future.value(serviceEnabled);
+  }
+
+  @override
+  Future<LocationPermission> checkPermission() => Future.value(permission);
+
+  @override
+  Future<LocationPermission> requestPermission() => Future.value(permission);
+
+  @override
+  Future<Position> getCurrentPosition({LocationSettings? locationSettings}) {
+    currentPositionCalls++;
+    if (currentPositionError != null) {
+      return Future.error(currentPositionError!);
+    }
+    final gated = pending;
+    if (gated != null) return gated;
+    return Future.value(currentPosition!);
+  }
+
+  @override
+  Future<Position?> getLastKnownPosition({bool forceLocationManager = false}) =>
+      Future.value(lastKnownPosition);
+}

--- a/test/prayer_schedule_anchor_test.dart
+++ b/test/prayer_schedule_anchor_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shia_companion/constants.dart';
+import 'package:shia_companion/utils/shared_preferences.dart';
+import 'package:shia_companion/utils/timezone_database.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+/// The schedule anchor decides when up to twelve days of azan notifications get
+/// torn down and rebuilt, so what counts as "moved" matters more here than
+/// anywhere else in the app.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SP.init();
+    // The fingerprint names the local zone, which is otherwise uninitialised
+    // outside the app.
+    ensureTimeZoneDatabaseInitialized();
+    tz.setLocalLocation(tz.UTC);
+    lat = null;
+    long = null;
+  });
+
+  Future<void> anchorAt(double latitude, double longitude) async {
+    await SP.prefs.setDouble('prayer_schedule_anchor_lat', latitude);
+    await SP.prefs.setDouble('prayer_schedule_anchor_long', longitude);
+  }
+
+  test('no location means nothing to reschedule for', () {
+    expect(hasPrayerScheduleLocationMoved(), isFalse);
+  });
+
+  test('a first fix with no anchor counts as a move', () {
+    lat = 32.6;
+    long = 44.0;
+
+    expect(hasPrayerScheduleLocationMoved(), isTrue);
+  });
+
+  test('GPS jitter is not a move', () async {
+    await anchorAt(32.6, 44.0);
+    // ~11 m, which used to trigger a full reschedule.
+    lat = 32.6001;
+    long = 44.0001;
+
+    expect(hasPrayerScheduleLocationMoved(), isFalse);
+  });
+
+  test('jitter across a rounding boundary is still not a move', () async {
+    // The bug a bucketed fingerprint would reintroduce: 32.604 and 32.606 round
+    // to different 2dp buckets while being 200 m apart.
+    await anchorAt(32.604, 44.0);
+    lat = 32.606;
+    long = 44.0;
+
+    expect(hasPrayerScheduleLocationMoved(), isFalse);
+  });
+
+  test('jitter never accumulates into a move', () async {
+    await anchorAt(32.6, 44.0);
+
+    // Repeated readings drifting around the anchor are each compared to the
+    // anchor, not to the previous reading, so they cannot ratchet.
+    for (final drift in [0.002, -0.003, 0.004, -0.001, 0.003]) {
+      lat = 32.6 + drift;
+      long = 44.0 + drift;
+      expect(hasPrayerScheduleLocationMoved(), isFalse);
+    }
+  });
+
+  test('travelling far enough is a move', () async {
+    await anchorAt(32.6, 44.0);
+    // ~5 km north.
+    lat = 32.645;
+    long = 44.0;
+
+    expect(hasPrayerScheduleLocationMoved(), isTrue);
+  });
+
+  test('the fingerprint no longer carries raw coordinates', () async {
+    lat = 32.6;
+    long = 44.0;
+    final atOrigin = buildPrayerNotificationScheduleFingerprint();
+
+    // Coordinates are tracked by the anchor and its distance threshold, so a
+    // small move must not flip the fingerprint on its own.
+    lat = 32.6001;
+    long = 44.0001;
+
+    expect(buildPrayerNotificationScheduleFingerprint(), atOrigin);
+  });
+
+  test('a stale schedule is detected when the device has really moved',
+      () async {
+    lat = 32.6;
+    long = 44.0;
+    await SP.prefs.setString(
+      prayerNotificationScheduleFingerprintKey,
+      buildPrayerNotificationScheduleFingerprint(),
+    );
+    await anchorAt(32.6, 44.0);
+
+    expect(shouldRefreshPrayerNotificationSchedule(const []), isFalse);
+
+    lat = 33.6;
+    expect(shouldRefreshPrayerNotificationSchedule(const []), isTrue);
+  });
+}

--- a/test/prayer_times_widget_test.dart
+++ b/test/prayer_times_widget_test.dart
@@ -1,0 +1,176 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shia_companion/constants.dart';
+import 'package:shia_companion/services/location_service.dart';
+import 'package:shia_companion/utils/shared_preferences.dart';
+import 'package:shia_companion/widgets/prayer_times_widget.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final service = LocationService.instance;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SP.init();
+    lat = null;
+    long = null;
+    city = null;
+    lastLocationFailure = null;
+    service.resetForTest();
+  });
+
+  Position _pos(double latitude, double longitude) => Position(
+        latitude: latitude,
+        longitude: longitude,
+        timestamp: DateTime.now(),
+        accuracy: 1,
+        altitude: 0,
+        altitudeAccuracy: 1,
+        heading: 0,
+        headingAccuracy: 1,
+        speed: 0,
+        speedAccuracy: 1,
+      );
+
+  Future<void> pumpCard(WidgetTester tester) {
+    return tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: HomePrayerTimesCard()),
+    ));
+  }
+
+  Future<T> withGeocode<T>(Future<T> Function() body) {
+    return http.runWithClient(
+      body,
+      () => MockClient((request) async => http.Response(
+            '{"locality":"Najaf","city":"Najaf","countryCode":"IQ"}',
+            200,
+          )),
+    );
+  }
+
+  testWidgets('keeps showing prayer times while a refresh is in flight',
+      (tester) async {
+    lat = 32.02;
+    long = 44.34;
+    city = 'Najaf';
+    final gate = Completer<Position>();
+    GeolocatorPlatform.instance = _FakeGeolocator(pending: gate.future);
+
+    await pumpCard(tester);
+    expect(find.text('Fajr'), findsOneWidget);
+    expect(find.text('Location: Najaf'), findsOneWidget);
+
+    await withGeocode(() async {
+      unawaited(service.refresh());
+      await tester.pump();
+
+      // The whole point: a spinner appears, and nothing else moves.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Fajr'), findsOneWidget);
+      expect(find.text('Zuhr'), findsOneWidget);
+      expect(find.text('Maghrib'), findsOneWidget);
+      expect(find.text('Location: Najaf'), findsOneWidget);
+
+      gate.complete(_pos(32.02, 44.34));
+      await tester.pumpAndSettle();
+    });
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.byIcon(Icons.refresh), findsOneWidget);
+  });
+
+  testWidgets('keeps the times and offers a retry when a refresh fails',
+      (tester) async {
+    lat = 32.02;
+    long = 44.34;
+    city = 'Najaf';
+    GeolocatorPlatform.instance = _FakeGeolocator(serviceEnabled: false);
+
+    await pumpCard(tester);
+    await withGeocode(() => service.refresh());
+    await tester.pump();
+
+    expect(find.text('Fajr'), findsOneWidget);
+    expect(find.textContaining('Location services are off'), findsOneWidget);
+    expect(find.byIcon(Icons.refresh), findsOneWidget);
+  });
+
+  testWidgets('offers a refresh even when the location has never resolved',
+      (tester) async {
+    GeolocatorPlatform.instance = _FakeGeolocator(serviceEnabled: false);
+
+    await pumpCard(tester);
+    expect(find.text('Location not available'), findsOneWidget);
+    expect(find.text('Tap here to enable location'), findsOneWidget);
+
+    // Must not become an untappable spinner: the empty state is the only way
+    // back once a location fetch has failed.
+    await withGeocode(() => service.refresh());
+    await tester.pump();
+
+    expect(find.text('Location services are off'), findsOneWidget);
+    expect(find.text('Tap to try again'), findsOneWidget);
+
+    // And the retry is genuinely wired, not just a label.
+    expect(
+      tester.widget<InkWell>(find.ancestor(
+        of: find.text('Tap to try again'),
+        matching: find.byType(InkWell),
+      )).onTap,
+      isNotNull,
+    );
+  });
+
+  testWidgets('discloses the age of a stale reading', (tester) async {
+    lat = 32.02;
+    long = 44.34;
+    city = 'Najaf';
+    service.setUpdatedAtForTest(
+      DateTime.now().subtract(const Duration(hours: 30)),
+    );
+    GeolocatorPlatform.instance = _FakeGeolocator();
+
+    await pumpCard(tester);
+
+    expect(find.textContaining('updated 1d ago'), findsOneWidget);
+  });
+}
+
+class _FakeGeolocator extends GeolocatorPlatform {
+  _FakeGeolocator({
+    this.pending,
+    this.serviceEnabled = true,
+  });
+
+  final Future<Position>? pending;
+  final bool serviceEnabled;
+
+  @override
+  Future<bool> isLocationServiceEnabled() => Future.value(serviceEnabled);
+
+  @override
+  Future<LocationPermission> checkPermission() =>
+      Future.value(LocationPermission.always);
+
+  @override
+  Future<LocationPermission> requestPermission() =>
+      Future.value(LocationPermission.always);
+
+  @override
+  Future<Position> getCurrentPosition({LocationSettings? locationSettings}) {
+    final gated = pending;
+    if (gated != null) return gated;
+    return Future.error(StateError('no position configured'));
+  }
+
+  @override
+  Future<Position?> getLastKnownPosition({bool forceLocationManager = false}) =>
+      Future.value(null);
+}


### PR DESCRIPTION
The reverse-geocode check was added to keep emulators from reporting an
ocean, but it grew a second requirement: a populated
`localityInfo.administrative` tree containing a country or first-order
subdivision entry. That rejects valid results wherever the administrative
hierarchy is shallow — city-states and small territories such as Bahrain,
Qatar, Singapore and Monaco — and the two-letter country code check that
precedes it had already established the coordinates were on land.

The rejection path then made things worse rather than degrading quietly. It
preferred `principalSubdivision`, so a rejected "Mountain View" became
"California"; failing that it wrote raw coordinates into the label, which
is published to the home screen widget and the watch complication and would
persist there; and it interrupted with a modal dialog. All of this for a
string that no calculation depends on — prayer times come from lat/long,
and are already correct by the time the geocoder is consulted.

Keep the country code, empty and coordinate-shaped checks, drop the
administrative tree requirement, and let every failure fall back to the
label we already had.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01242pCa1cRwy5TMKvUA5TxQ