### PR TITLE
Let users drag favorites into the order they want

### DIFF
--- a/lib/pages/favorites_page.dart
+++ b/lib/pages/favorites_page.dart
@@ -22,6 +22,17 @@ class _FavoritesPageState extends State<FavoritesPage> {
     await FavoritesManager.instance.loadFavorites();
   }
 
+  Future<void> _onReorder(int oldIndex, int newIndex) async {
+    try {
+      await FavoritesManager.instance.moveFavorite(oldIndex, newIndex);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not save the new order. Try again.')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final favoritesManager = FavoritesManager.instance;
@@ -46,29 +57,55 @@ class _FavoritesPageState extends State<FavoritesPage> {
           return ResponsiveContent(
             maxWidth: listContentWidth,
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: ListView.separated(
+            child: ReorderableListView.builder(
               padding: const EdgeInsets.symmetric(vertical: 8),
               itemCount: favorites.length,
-              separatorBuilder: (_, __) => Divider(),
+              buildDefaultDragHandles: false,
+              onReorderItem: _onReorder,
               itemBuilder: (context, index) {
                 UniversalData item = favorites[index];
-                return ListTile(
-                  title: isUserAdmin
-                      ? Text(item.uid + ' ' + item.title)
-                      : Text(item.title),
-                  onTap: () {
-                    handleUniversalDataClick(context, item);
-                  },
-                  onLongPress: () {
-                    if (isUserAdmin)
-                      handleUniversalDataClick(context, item, itemPage: true);
-                  },
-                  trailing: InkWell(
-                    onTap: () async {
-                      await FavoritesManager.instance.toggleFavorite(item);
-                    },
-                    child: FavoriteIcon(favorite: item),
-                  ),
+                return Column(
+                  key: ValueKey(item.favoriteKey),
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ListTile(
+                      title: isUserAdmin
+                          ? Text(item.uid + ' ' + item.title)
+                          : Text(item.title),
+                      onTap: () {
+                        handleUniversalDataClick(context, item);
+                      },
+                      onLongPress: () {
+                        if (isUserAdmin)
+                          handleUniversalDataClick(context, item,
+                              itemPage: true);
+                      },
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          InkWell(
+                            onTap: () async {
+                              await FavoritesManager.instance
+                                  .toggleFavorite(item);
+                            },
+                            child: FavoriteIcon(favorite: item),
+                          ),
+                          const SizedBox(width: 8),
+                          ReorderableDragStartListener(
+                            index: index,
+                            child: Padding(
+                              padding: const EdgeInsets.all(4),
+                              child: Icon(
+                                Icons.drag_handle,
+                                semanticLabel: 'Reorder ${item.title}',
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (index < favorites.length - 1) Divider(),
+                  ],
                 );
               },
             ),

--- a/lib/services/favorites_manager.dart
+++ b/lib/services/favorites_manager.dart
@@ -384,42 +384,23 @@ class FavoritesManager extends ChangeNotifier {
     return applyFavoriteOrder(favorites, pendingOrder.orderedKeys);
   }
 
-  _PendingFavoriteOrder? _loadPendingOrder(String userId) {
+  PendingFavoriteOrder? _loadPendingOrder(String userId) {
     final encoded = SP.prefs.getString(_pendingOrderStorageKey(userId));
-    if (encoded == null || encoded.isEmpty) return null;
-
-    try {
-      final parsed = jsonDecode(encoded);
-      if (parsed is! Map) return null;
-      final keys = parsed['keys'];
-      if (keys is! List) return null;
-      final orderedKeys = [
-        for (final key in keys)
-          if (key is String && key.trim().isNotEmpty) key,
-      ];
-      if (orderedKeys.isEmpty) return null;
-      final version = parsed['version'];
-      return _PendingFavoriteOrder(
-        version: version is int ? version : 0,
-        orderedKeys: orderedKeys,
-      );
-    } catch (error) {
-      debugPrint('FavoritesManager: Error decoding pending order: $error');
-      return null;
+    final order = decodePendingFavoriteOrder(encoded);
+    if (order == null && encoded != null && encoded.isNotEmpty) {
+      debugPrint('FavoritesManager: Discarded an unreadable pending order');
     }
+    return order;
   }
 
   Future<void> _recordPendingOrder(
     String userId,
-    _PendingFavoriteOrder order,
+    PendingFavoriteOrder order,
   ) {
     return _enqueueStorageWrite(() async {
       await SP.prefs.setString(
         _pendingOrderStorageKey(userId),
-        jsonEncode({
-          'version': order.version,
-          'keys': order.orderedKeys,
-        }),
+        encodePendingFavoriteOrder(order),
       );
     });
   }
@@ -428,8 +409,9 @@ class FavoritesManager extends ChangeNotifier {
   /// still waiting on the network survives an older write finishing late.
   Future<void> _clearPendingOrder(String userId, int version) {
     return _enqueueStorageWrite(() async {
-      final stored = _loadPendingOrder(userId);
-      if (stored != null && stored.version > version) return;
+      if (!shouldClearPendingFavoriteOrder(_loadPendingOrder(userId), version)) {
+        return;
+      }
       await SP.prefs.remove(_pendingOrderStorageKey(userId));
     });
   }
@@ -944,7 +926,7 @@ class FavoritesManager extends ChangeNotifier {
       return;
     }
 
-    final pendingOrder = _PendingFavoriteOrder(
+    final pendingOrder = PendingFavoriteOrder(
       version: _mutationVersion,
       orderedKeys: [
         for (final favorite in nextFavorites) favorite.favoriteKey,
@@ -1003,16 +985,6 @@ class FavoritesManager extends ChangeNotifier {
     debugPrint('FavoritesManager: Disposed listener');
     super.dispose();
   }
-}
-
-class _PendingFavoriteOrder {
-  const _PendingFavoriteOrder({
-    required this.version,
-    required this.orderedKeys,
-  });
-
-  final int version;
-  final List<String> orderedKeys;
 }
 
 class _RemoteFavoritesRead {

--- a/lib/services/favorites_manager.dart
+++ b/lib/services/favorites_manager.dart
@@ -45,6 +45,7 @@ class FavoritesManager extends ChangeNotifier {
   String? _loadedUserId;
   bool _isImportingGuestFavorites = false;
   bool _isReplayingPendingOperations = false;
+  bool _isReplayingPendingOrder = false;
   int _mutationVersion = 0;
   bool _isLoading = false;
   bool _hasLoadedFavorites = false;
@@ -69,6 +70,9 @@ class FavoritesManager extends ChangeNotifier {
 
   String _pendingOperationsStorageKey(String userId) =>
       'favorites_pending_operations_$userId';
+
+  String _pendingOrderStorageKey(String userId) =>
+      'favorites_pending_order_$userId';
 
   Future<void> loadFavorites() async {
     if (_loadFavoritesFuture != null) {
@@ -157,7 +161,7 @@ class FavoritesManager extends ChangeNotifier {
         pendingOperations,
       );
       resolvedFavorites = await _resolveTitles(
-        favoritesWithPendingOperations,
+        _applyPendingOrder(user.uid, favoritesWithPendingOperations),
         fallbacks: [
           ...userCachedFavorites,
           ...remoteRead.favorites,
@@ -203,10 +207,14 @@ class FavoritesManager extends ChangeNotifier {
       _pendingGuestFavorites = guestFavorites;
     }
 
-    if (remoteRead.succeeded &&
-        decision.remoteSeed == null &&
-        pendingOperations.isNotEmpty) {
-      await _replayPendingOperations(user.uid, pendingOperations);
+    if (remoteRead.succeeded && decision.remoteSeed == null) {
+      if (pendingOperations.isNotEmpty) {
+        await _replayPendingOperations(user.uid, pendingOperations);
+      }
+      await _replayPendingOrder(user.uid);
+    } else if (decision.remoteSeed != null && remoteMigrationSucceeded) {
+      // The seed write already published the current order.
+      await _clearPendingOrder(user.uid, _mutationVersion);
     }
 
     if (decision.canCleanUpLegacyData && remoteMigrationSucceeded) {
@@ -363,6 +371,84 @@ class FavoritesManager extends ChangeNotifier {
       operations.remove(favorite.favoriteKey);
       await _writePendingOperations(userId, operations.values);
     });
+  }
+
+  /// Firestore stores the entries in order, but a reorder that has not reached
+  /// the server yet has to be reapplied to whatever the server hands back.
+  List<UniversalData> _applyPendingOrder(
+    String userId,
+    List<UniversalData> favorites,
+  ) {
+    final pendingOrder = _loadPendingOrder(userId);
+    if (pendingOrder == null) return favorites;
+    return applyFavoriteOrder(favorites, pendingOrder.orderedKeys);
+  }
+
+  _PendingFavoriteOrder? _loadPendingOrder(String userId) {
+    final encoded = SP.prefs.getString(_pendingOrderStorageKey(userId));
+    if (encoded == null || encoded.isEmpty) return null;
+
+    try {
+      final parsed = jsonDecode(encoded);
+      if (parsed is! Map) return null;
+      final keys = parsed['keys'];
+      if (keys is! List) return null;
+      final orderedKeys = [
+        for (final key in keys)
+          if (key is String && key.trim().isNotEmpty) key,
+      ];
+      if (orderedKeys.isEmpty) return null;
+      final version = parsed['version'];
+      return _PendingFavoriteOrder(
+        version: version is int ? version : 0,
+        orderedKeys: orderedKeys,
+      );
+    } catch (error) {
+      debugPrint('FavoritesManager: Error decoding pending order: $error');
+      return null;
+    }
+  }
+
+  Future<void> _recordPendingOrder(
+    String userId,
+    _PendingFavoriteOrder order,
+  ) {
+    return _enqueueStorageWrite(() async {
+      await SP.prefs.setString(
+        _pendingOrderStorageKey(userId),
+        jsonEncode({
+          'version': order.version,
+          'keys': order.orderedKeys,
+        }),
+      );
+    });
+  }
+
+  /// Drops the marker only when no newer reorder has replaced it, so a reorder
+  /// still waiting on the network survives an older write finishing late.
+  Future<void> _clearPendingOrder(String userId, int version) {
+    return _enqueueStorageWrite(() async {
+      final stored = _loadPendingOrder(userId);
+      if (stored != null && stored.version > version) return;
+      await SP.prefs.remove(_pendingOrderStorageKey(userId));
+    });
+  }
+
+  Future<void> _replayPendingOrder(String userId) async {
+    if (_isReplayingPendingOrder) return;
+    await _storageWriteQueue;
+    final pendingOrder = _loadPendingOrder(userId);
+    if (pendingOrder == null) return;
+
+    _isReplayingPendingOrder = true;
+    try {
+      await _saveRemoteFavoritesForUser(userId, _favorites);
+      await _clearPendingOrder(userId, pendingOrder.version);
+    } catch (error) {
+      debugPrint('FavoritesManager: Pending order replay failed: $error');
+    } finally {
+      _isReplayingPendingOrder = false;
+    }
   }
 
   Future<void> _writePendingOperations(
@@ -650,6 +736,7 @@ class FavoritesManager extends ChangeNotifier {
           remoteFavorites,
           pendingOperations,
         );
+        remoteFavorites = _applyPendingOrder(user.uid, remoteFavorites);
         final versionBeforeResolution = _mutationVersion;
 
         final resolvedFavorites = await _resolveTitles(
@@ -664,6 +751,7 @@ class FavoritesManager extends ChangeNotifier {
         if (pendingOperations.isNotEmpty) {
           unawaited(_replayPendingOperations(user.uid, pendingOperations));
         }
+        unawaited(_replayPendingOrder(user.uid));
         debugPrint(
           'FavoritesManager: Loaded ${resolvedFavorites.length} favorites from Firestore',
         );
@@ -836,6 +924,47 @@ class FavoritesManager extends ChangeNotifier {
     }
   }
 
+  /// Moves the favorite at [fromIndex] so that it ends up at [toIndex] in the
+  /// resulting list, matching the indices `ReorderableListView.onReorderItem`
+  /// reports.
+  Future<void> moveFavorite(int fromIndex, int toIndex) async {
+    final reordered = List<UniversalData>.from(_favorites);
+    if (fromIndex < 0 || fromIndex >= reordered.length) return;
+    final destination = toIndex.clamp(0, reordered.length - 1);
+    if (destination == fromIndex) return;
+
+    reordered.insert(destination, reordered.removeAt(fromIndex));
+    _updateFavoritesData(reordered, isUserMutation: true);
+
+    final nextFavorites = _favorites;
+    final user = _auth.currentUser;
+    if (user == null) {
+      await _saveGuestFavorites(nextFavorites, markForImport: true);
+      debugPrint('FavoritesManager: Reordered favorites (guest)');
+      return;
+    }
+
+    final pendingOrder = _PendingFavoriteOrder(
+      version: _mutationVersion,
+      orderedKeys: [
+        for (final favorite in nextFavorites) favorite.favoriteKey,
+      ],
+    );
+
+    try {
+      await Future.wait([
+        _saveUserFavoritesToSharedPreferences(user.uid, nextFavorites),
+        _recordPendingOrder(user.uid, pendingOrder),
+      ]);
+      await _saveRemoteFavoritesForUser(user.uid, nextFavorites);
+      await _clearPendingOrder(user.uid, pendingOrder.version);
+      debugPrint('FavoritesManager: Reordered favorites (Firestore)');
+    } catch (e) {
+      debugPrint('FavoritesManager: Error reordering favorites: $e');
+      rethrow;
+    }
+  }
+
   bool isFavorite(UniversalData item) {
     return _favorites.contains(_normalizeFavorite(item));
   }
@@ -855,6 +984,7 @@ class FavoritesManager extends ChangeNotifier {
       await _enqueueStorageWrite(() async {
         await SP.prefs.remove(_userStorageKey(userId));
         await SP.prefs.remove(_pendingOperationsStorageKey(userId));
+        await SP.prefs.remove(_pendingOrderStorageKey(userId));
       });
 
       if (_auth.currentUser?.uid == userId) {
@@ -873,6 +1003,16 @@ class FavoritesManager extends ChangeNotifier {
     debugPrint('FavoritesManager: Disposed listener');
     super.dispose();
   }
+}
+
+class _PendingFavoriteOrder {
+  const _PendingFavoriteOrder({
+    required this.version,
+    required this.orderedKeys,
+  });
+
+  final int version;
+  final List<String> orderedKeys;
 }
 
 class _RemoteFavoritesRead {

--- a/lib/services/favorites_sync_policy.dart
+++ b/lib/services/favorites_sync_policy.dart
@@ -77,6 +77,37 @@ List<UniversalData> _deduplicate(Iterable<UniversalData> source) {
   ];
 }
 
+/// Restores a user's manual ordering on top of a server list that has no
+/// ordering of its own to offer.
+///
+/// Entries missing from [orderedKeys] (favorites added elsewhere since the
+/// reorder) keep their relative order and land after the ordered ones.
+List<UniversalData> applyFavoriteOrder(
+  Iterable<UniversalData> favorites,
+  Iterable<String> orderedKeys,
+) {
+  final ranks = <String, int>{};
+  for (final key in orderedKeys) {
+    ranks.putIfAbsent(key, () => ranks.length);
+  }
+
+  final entries = favorites.toList(growable: false);
+  if (ranks.isEmpty) return entries;
+
+  final unrankedOffset = ranks.length;
+  final decorated = [
+    for (var index = 0; index < entries.length; index++)
+      (
+        rank: ranks[entries[index].favoriteKey] ?? unrankedOffset + index,
+        index: index,
+        favorite: entries[index],
+      ),
+  ]..sort((a, b) =>
+      a.rank != b.rank ? a.rank.compareTo(b.rank) : a.index.compareTo(b.index));
+
+  return [for (final entry in decorated) entry.favorite];
+}
+
 List<UniversalData> applyPendingFavoriteOperations(
   Iterable<UniversalData> favorites,
   Iterable<PendingFavoriteOperation> operations,

--- a/lib/services/favorites_sync_policy.dart
+++ b/lib/services/favorites_sync_policy.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import '../data/universal_data.dart';
 
 class FavoritesSyncDecision {
@@ -75,6 +77,63 @@ List<UniversalData> _deduplicate(Iterable<UniversalData> source) {
     for (final favorite in source)
       if (seen.add(favorite.favoriteKey)) favorite,
   ];
+}
+
+/// A reorder that has not reached the server yet.
+///
+/// [version] is the mutation counter the reorder was recorded at, which is what
+/// lets a late write tell its own reorder apart from a newer one.
+class PendingFavoriteOrder {
+  const PendingFavoriteOrder({
+    required this.version,
+    required this.orderedKeys,
+  });
+
+  final int version;
+  final List<String> orderedKeys;
+}
+
+String encodePendingFavoriteOrder(PendingFavoriteOrder order) {
+  return jsonEncode({
+    'version': order.version,
+    'keys': order.orderedKeys,
+  });
+}
+
+/// Returns null for anything that cannot be read back as an ordering, so a
+/// corrupt marker is dropped instead of scrambling the list.
+PendingFavoriteOrder? decodePendingFavoriteOrder(String? encoded) {
+  if (encoded == null || encoded.isEmpty) return null;
+
+  try {
+    final parsed = jsonDecode(encoded);
+    if (parsed is! Map) return null;
+    final keys = parsed['keys'];
+    if (keys is! List) return null;
+    final orderedKeys = [
+      for (final key in keys)
+        if (key is String && key.trim().isNotEmpty) key,
+    ];
+    if (orderedKeys.isEmpty) return null;
+    final version = parsed['version'];
+    return PendingFavoriteOrder(
+      version: version is int ? version : 0,
+      orderedKeys: orderedKeys,
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Whether a write that published [version] may drop [stored].
+///
+/// A marker recorded after that write belongs to a reorder still waiting on the
+/// network, so clearing it would lose the newer ordering.
+bool shouldClearPendingFavoriteOrder(
+  PendingFavoriteOrder? stored,
+  int version,
+) {
+  return stored == null || stored.version <= version;
 }
 
 /// Restores a user's manual ordering on top of a server list that has no

--- a/test/favorites_sync_policy_test.dart
+++ b/test/favorites_sync_policy_test.dart
@@ -133,6 +133,55 @@ void main() {
     expect(applyFavoriteOrder([first, second], const []), [first, second]);
   });
 
+  test('a recorded order survives the round trip through storage', () {
+    final encoded = encodePendingFavoriteOrder(
+      PendingFavoriteOrder(version: 7, orderedKeys: ['1:second', '1:first']),
+    );
+
+    final decoded = decodePendingFavoriteOrder(encoded);
+
+    expect(decoded?.version, 7);
+    expect(decoded?.orderedKeys, ['1:second', '1:first']);
+  });
+
+  test('an unreadable marker is discarded rather than half applied', () {
+    expect(decodePendingFavoriteOrder(null), isNull);
+    expect(decodePendingFavoriteOrder(''), isNull);
+    expect(decodePendingFavoriteOrder('not json'), isNull);
+    expect(decodePendingFavoriteOrder('["1:first"]'), isNull);
+    expect(decodePendingFavoriteOrder('{"version":1}'), isNull);
+    expect(decodePendingFavoriteOrder('{"version":1,"keys":"1:first"}'), isNull);
+    expect(decodePendingFavoriteOrder('{"version":1,"keys":[]}'), isNull);
+  });
+
+  test('unusable keys are dropped, and a marker left with none is too', () {
+    final decoded = decodePendingFavoriteOrder(
+      '{"version":1,"keys":["1:first",2,"","   ",null,"1:second"]}',
+    );
+
+    expect(decoded?.orderedKeys, ['1:first', '1:second']);
+    expect(
+      decodePendingFavoriteOrder('{"version":1,"keys":[2,"",null]}'),
+      isNull,
+    );
+  });
+
+  test('a marker written before versioning is treated as the oldest', () {
+    final decoded = decodePendingFavoriteOrder('{"keys":["1:first"]}');
+
+    expect(decoded?.version, 0);
+    expect(shouldClearPendingFavoriteOrder(decoded, 0), isTrue);
+  });
+
+  test('a write only clears the reorder it published, or an older one', () {
+    final stored = PendingFavoriteOrder(version: 5, orderedKeys: ['1:first']);
+
+    expect(shouldClearPendingFavoriteOrder(stored, 5), isTrue);
+    expect(shouldClearPendingFavoriteOrder(stored, 6), isTrue);
+    expect(shouldClearPendingFavoriteOrder(stored, 4), isFalse);
+    expect(shouldClearPendingFavoriteOrder(null, 5), isTrue);
+  });
+
   test('the latest pending operation for an item determines its state', () {
     final favoriteToToggle = favorite('toggle');
 

--- a/test/favorites_sync_policy_test.dart
+++ b/test/favorites_sync_policy_test.dart
@@ -99,6 +99,40 @@ void main() {
     expect(favorites, [kept]);
   });
 
+  test('a pending reorder survives a server list that predates it', () {
+    final first = favorite('first');
+    final second = favorite('second');
+    final third = favorite('third');
+
+    final favorites = applyFavoriteOrder(
+      [first, second, third],
+      [third.favoriteKey, first.favoriteKey, second.favoriteKey],
+    );
+
+    expect(favorites, [third, first, second]);
+  });
+
+  test('favorites added since the reorder keep their order at the end', () {
+    final reordered = favorite('reordered');
+    final untouched = favorite('untouched');
+    final addedElsewhere = favorite('added-elsewhere');
+    final addedLater = favorite('added-later');
+
+    final favorites = applyFavoriteOrder(
+      [untouched, addedElsewhere, reordered, addedLater],
+      [reordered.favoriteKey, untouched.favoriteKey],
+    );
+
+    expect(favorites, [reordered, untouched, addedElsewhere, addedLater]);
+  });
+
+  test('an empty order leaves the list untouched', () {
+    final first = favorite('first');
+    final second = favorite('second');
+
+    expect(applyFavoriteOrder([first, second], const []), [first, second]);
+  });
+
   test('the latest pending operation for an item determines its state', () {
     final favoriteToToggle = favorite('toggle');
 


### PR DESCRIPTION
Favorites were locked into the order they happened to be added in. The
list is now a ReorderableListView with a per-row drag handle, and the
new order is persisted everywhere the list is: the local cache, the
guest store, and the ordered entries array in Firestore.

A reorder that cannot reach Firestore leaves a pending-order marker in
shared preferences alongside the existing pending add/remove markers, so
a stale server snapshot arriving afterwards no longer snaps the list
back. The marker carries the mutation version that recorded it, so a
write finishing late cannot clear a newer reorder that is still waiting,
and favorites added elsewhere since the reorder keep their relative
order at the end of the list.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019wx9fvRiUBz2Zt2J6jNaaS