### PR TITLE
Give the zikr page room for its title and show reading progress

### DIFF
--- a/lib/pages/chapter_page.dart
+++ b/lib/pages/chapter_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shia_companion/data/uid_title_data.dart';

--- a/lib/pages/zikr/zikr_content_viewer.dart
+++ b/lib/pages/zikr/zikr_content_viewer.dart
@@ -7,10 +7,12 @@ class ZikrContentScrollPosition {
   const ZikrContentScrollPosition({
     required this.tabIndex,
     required this.scrollOffset,
+    this.maxScrollExtent = 0,
   });
 
   final int tabIndex;
   final double scrollOffset;
+  final double maxScrollExtent;
 }
 
 class ZikrContentViewerWidget extends StatefulWidget {
@@ -138,20 +140,38 @@ class _ZikrContentViewerWidgetState extends State<ZikrContentViewerWidget> {
     while (_tabScrollControllers.length < count) {
       final tabIndex = _tabScrollControllers.length;
       final controller = ScrollController();
-      controller.addListener(() {
-        if (!controller.hasClients) return;
-        widget.onScrollPositionChanged?.call(
-          ZikrContentScrollPosition(
-            tabIndex: tabIndex,
-            scrollOffset: controller.offset,
-          ),
-        );
-      });
+      controller.addListener(() => _reportScrollPosition(tabIndex, controller));
       _tabScrollControllers.add(controller);
     }
     while (_tabScrollControllers.length > count) {
       _tabScrollControllers.removeLast().dispose();
     }
+  }
+
+  void _reportScrollPosition(int tabIndex, ScrollController controller) {
+    if (widget.onScrollPositionChanged == null || !controller.hasClients) {
+      return;
+    }
+
+    final position = controller.position;
+    widget.onScrollPositionChanged!.call(
+      ZikrContentScrollPosition(
+        tabIndex: tabIndex,
+        scrollOffset: position.pixels,
+        maxScrollExtent: position.maxScrollExtent,
+      ),
+    );
+  }
+
+  /// Publishes the position of a tab that has not been scrolled yet, so
+  /// progress is known as soon as a tab is laid out or swiped to.
+  void _scheduleScrollPositionReport(int tabIndex) {
+    if (widget.onScrollPositionChanged == null) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || tabIndex >= _tabScrollControllers.length) return;
+      _reportScrollPosition(tabIndex, _tabScrollControllers[tabIndex]);
+    });
   }
 
   void _restoreInitialBookmarkIfNeeded(
@@ -250,6 +270,9 @@ class _ZikrContentViewerWidgetState extends State<ZikrContentViewerWidget> {
     required bool showMeritsButton,
   }) {
     _restoreInitialBookmarkIfNeeded(tabIndex, controller);
+    if (tabIndex == _selectedTabIndex) {
+      _scheduleScrollPositionReport(tabIndex);
+    }
 
     final parsedContent = ZikrContentParser.parseContent(
       rawContent,
@@ -266,82 +289,90 @@ class _ZikrContentViewerWidgetState extends State<ZikrContentViewerWidget> {
     final transliStyle =
         TextStyle(fontWeight: FontWeight.bold, fontSize: englishFontSize);
 
-    return Scrollbar(
-      controller: controller,
-      child: ListView.builder(
+    return NotificationListener<ScrollMetricsNotification>(
+      onNotification: (notification) {
+        if (tabIndex == _selectedTabIndex) {
+          _reportScrollPosition(tabIndex, controller);
+        }
+        return false;
+      },
+      child: Scrollbar(
         controller: controller,
-        itemCount: parsedContent.lines.length + (showMeritsButton ? 1 : 0),
-        itemBuilder: (BuildContext context, int index) {
-          // Show merits button at the top of first tab
-          if (showMeritsButton && index == 0) {
-            return Padding(
-              padding: const EdgeInsets.only(
-                left: 16.0,
-                top: 12.0,
-                right: 16.0,
-                bottom: 12.0,
-              ),
-              child: InkWell(
-                onTap: widget.onShowMerits,
-                child: Text(
-                  'Merits',
-                  style: TextStyle(
-                    decoration: TextDecoration.underline,
-                    fontSize: 14,
+        child: ListView.builder(
+          controller: controller,
+          itemCount: parsedContent.lines.length + (showMeritsButton ? 1 : 0),
+          itemBuilder: (BuildContext context, int index) {
+            // Show merits button at the top of first tab
+            if (showMeritsButton && index == 0) {
+              return Padding(
+                padding: const EdgeInsets.only(
+                  left: 16.0,
+                  top: 12.0,
+                  right: 16.0,
+                  bottom: 12.0,
+                ),
+                child: InkWell(
+                  onTap: widget.onShowMerits,
+                  child: Text(
+                    'Merits',
+                    style: TextStyle(
+                      decoration: TextDecoration.underline,
+                      fontSize: 14,
+                    ),
                   ),
                 ),
-              ),
-            );
-          }
+              );
+            }
 
-          // Adjust content index for merits button
-          final contentIndex = showMeritsButton ? index - 1 : index;
-          final str = parsedContent.lines[contentIndex].trim();
+            // Adjust content index for merits button
+            final contentIndex = showMeritsButton ? index - 1 : index;
+            final str = parsedContent.lines[contentIndex].trim();
 
-          if (parsedContent.arabicCodes.contains(contentIndex)) {
-            return Padding(
-              padding: const EdgeInsets.only(top: 12.0, bottom: 4.0),
-              child: Text.rich(
-                _buildTextSpanForLine(
-                  ZikrContentParser.formatArabicText(str),
-                  arabicStyle,
+            if (parsedContent.arabicCodes.contains(contentIndex)) {
+              return Padding(
+                padding: const EdgeInsets.only(top: 12.0, bottom: 4.0),
+                child: Text.rich(
+                  _buildTextSpanForLine(
+                    ZikrContentParser.formatArabicText(str),
+                    arabicStyle,
+                  ),
+                  textAlign: TextAlign.center,
+                  textDirection: TextDirection.rtl,
                 ),
-                textAlign: TextAlign.center,
-                textDirection: TextDirection.rtl,
-              ),
-            );
-          } else if (parsedContent.transliCodes.contains(contentIndex)) {
-            return showTransliteration
-                ? Text.rich(
-                    _buildTextSpanForLine(str.toUpperCase(), transliStyle),
-                    textAlign: TextAlign.center,
-                  )
-                : Container();
-          } else if (parsedContent.translaCodes.contains(contentIndex)) {
-            return showTranslation
-                ? Padding(
-                    padding: const EdgeInsets.only(bottom: 4.0),
-                    child: Text.rich(
-                      _buildTextSpanForLine(
-                        str,
-                        TextStyle(fontSize: englishFontSize),
-                      ),
+              );
+            } else if (parsedContent.transliCodes.contains(contentIndex)) {
+              return showTransliteration
+                  ? Text.rich(
+                      _buildTextSpanForLine(str.toUpperCase(), transliStyle),
                       textAlign: TextAlign.center,
-                    ),
-                  )
-                : Container();
-          } else {
-            return Padding(
-              padding: const EdgeInsets.only(top: 8, bottom: 4.0),
-              child: Text.rich(
-                _buildTextSpanForLine(
-                  str,
-                  const TextStyle(fontStyle: FontStyle.italic),
+                    )
+                  : Container();
+            } else if (parsedContent.translaCodes.contains(contentIndex)) {
+              return showTranslation
+                  ? Padding(
+                      padding: const EdgeInsets.only(bottom: 4.0),
+                      child: Text.rich(
+                        _buildTextSpanForLine(
+                          str,
+                          TextStyle(fontSize: englishFontSize),
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    )
+                  : Container();
+            } else {
+              return Padding(
+                padding: const EdgeInsets.only(top: 8, bottom: 4.0),
+                child: Text.rich(
+                  _buildTextSpanForLine(
+                    str,
+                    const TextStyle(fontStyle: FontStyle.italic),
+                  ),
                 ),
-              ),
-            );
-          }
-        },
+              );
+            }
+          },
+        ),
       ),
     );
   }
@@ -441,6 +472,7 @@ class _ZikrContentViewerWidgetState extends State<ZikrContentViewerWidget> {
               });
               widget.onTabChanged(index);
               _centerSelectedTab();
+              _scheduleScrollPositionReport(index);
             },
             itemBuilder: (context, index) => _buildTabContent(
               widget.tabContents[index],

--- a/lib/pages/zikr/zikr_page.dart
+++ b/lib/pages/zikr/zikr_page.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:share_plus/share_plus.dart';
@@ -834,25 +833,15 @@ class _ZikrPageState extends State<ZikrPage> with RouteAware {
       tabContents,
       hideHeaderLine: hideHeaderLine,
     );
-    _updateReadingProgress();
+    // This runs from build, so the notifier is written once the frame is done.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _updateReadingProgress();
+    });
   }
 
   void _updateReadingProgress() {
-    final next = _computeReadingProgress();
-    if (next == _readingProgress.value) return;
-
-    // Progress is recomputed while the page is building or laying out, so the
-    // notifier is only written once the frame is done.
-    if (SchedulerBinding.instance.schedulerPhase ==
-        SchedulerPhase.persistentCallbacks) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        _readingProgress.value = next;
-      });
-      return;
-    }
-
-    _readingProgress.value = next;
+    _readingProgress.value = _computeReadingProgress();
   }
 
   double _computeReadingProgress() {

--- a/lib/pages/zikr/zikr_page.dart
+++ b/lib/pages/zikr/zikr_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:share_plus/share_plus.dart';
@@ -15,13 +16,17 @@ import 'package:shia_companion/utils/web_route_sync.dart';
 import 'package:shia_companion/utils/zikr_wakelock.dart';
 import '../../constants.dart';
 import '../../widgets/responsive_content.dart';
+import '../../widgets/zikr_reading_preferences.dart';
 import '../../widgets/zikr_settings.dart';
 import '../../widgets/zikr_counter.dart';
 import 'zikr_edit_form.dart';
 import 'zikr_form_helpers.dart';
 import 'zikr_content_parser.dart';
 import 'zikr_content_viewer.dart';
+import 'zikr_reading_stats.dart';
 import 'zikr_share_image.dart';
+
+enum _ZikrMenuAction { share, readingSettings, edit }
 
 class ZikrPage extends StatefulWidget {
   final UidTitleData item;
@@ -34,6 +39,10 @@ class ZikrPage extends StatefulWidget {
 
 class _ZikrPageState extends State<ZikrPage> with RouteAware {
   static const String _bookmarkHintSeenKey = 'zikr_bookmark_hint_seen_v1';
+
+  /// Below this width the app bar keeps only the bookmark icon so a long zikr
+  /// title is not squeezed out by the action row.
+  static const double _compactActionsWidth = 420;
 
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final CollectionReference zikrCollection =
@@ -60,7 +69,12 @@ class _ZikrPageState extends State<ZikrPage> with RouteAware {
   Uri? _previousBrowserUri;
   List<String> _slugAliases = const [];
   ZikrBookmark? _savedBookmark;
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   final Map<int, double> _currentTabScrollOffsets = {};
+  final Map<int, double> _currentTabMaxScrollExtents = {};
+  final ValueNotifier<double> _readingProgress = ValueNotifier<double>(0);
+  ZikrReadingStats _readingStats = ZikrReadingStats.empty;
+  String? _readingStatsSignature;
   late final String _counterSessionId;
   late final ValueNotifier<Offset> _counterOffset;
   late final ValueNotifier<bool> _showCounter;
@@ -101,6 +115,7 @@ class _ZikrPageState extends State<ZikrPage> with RouteAware {
     _counterOffset.dispose();
     _showCounter.dispose();
     _counterCount.dispose();
+    _readingProgress.dispose();
     syncZikrWakelockPreference(owner: this, isActive: false);
     super.dispose();
   }
@@ -801,6 +816,64 @@ class _ZikrPageState extends State<ZikrPage> with RouteAware {
     ZikrContentScrollPosition position,
   ) {
     _currentTabScrollOffsets[position.tabIndex] = position.scrollOffset;
+    _currentTabMaxScrollExtents[position.tabIndex] = position.maxScrollExtent;
+    _updateReadingProgress();
+  }
+
+  /// Recomputes the reading estimate only when the rendered text changed, since
+  /// this runs on every rebuild of the page.
+  void _refreshReadingStats(
+    List<String> tabContents, {
+    required bool hideHeaderLine,
+  }) {
+    final signature = '$hideHeaderLine|${tabContents.join('\n')}';
+    if (signature == _readingStatsSignature) return;
+
+    _readingStatsSignature = signature;
+    _readingStats = analyzeZikrReadingStats(
+      tabContents,
+      hideHeaderLine: hideHeaderLine,
+    );
+    _updateReadingProgress();
+  }
+
+  void _updateReadingProgress() {
+    final next = _computeReadingProgress();
+    if (next == _readingProgress.value) return;
+
+    // Progress is recomputed while the page is building or laying out, so the
+    // notifier is only written once the frame is done.
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _readingProgress.value = next;
+      });
+      return;
+    }
+
+    _readingProgress.value = next;
+  }
+
+  double _computeReadingProgress() {
+    final weights = _readingStats.tabWeights;
+    if (weights.isEmpty) return 0;
+
+    final tabIndex = _selectedZikrTabIndex.clamp(0, weights.length - 1);
+    final maxScrollExtent = _currentTabMaxScrollExtents[tabIndex];
+    // An unmeasured tab has not been laid out yet, so nothing is read.
+    final tabFraction = maxScrollExtent == null
+        ? 0.0
+        : zikrTabScrollFraction(
+            scrollOffset: _currentTabScrollOffsets[tabIndex] ?? 0,
+            maxScrollExtent: maxScrollExtent,
+          );
+
+    return zikrReadingProgress(
+      tabWeights: weights,
+      tabIndex: tabIndex,
+      tabFraction: tabFraction,
+    );
   }
 
   Future<void> _toggleBookmark({
@@ -914,6 +987,174 @@ class _ZikrPageState extends State<ZikrPage> with RouteAware {
     }
   }
 
+  Widget _buildAppBarTitle(String title) {
+    // Long titles wrap onto a second, smaller line instead of being clipped.
+    final useTwoLines = title.trim().length > 24;
+    return Text(
+      title,
+      maxLines: useTwoLines ? 2 : 1,
+      overflow: TextOverflow.ellipsis,
+      style: useTwoLines ? const TextStyle(fontSize: 16, height: 1.2) : null,
+    );
+  }
+
+  void _handleMenuAction(_ZikrMenuAction action) {
+    switch (action) {
+      case _ZikrMenuAction.share:
+        if (!_isSharingZikr) _shareCurrentZikr();
+        break;
+      case _ZikrMenuAction.readingSettings:
+        _scaffoldKey.currentState?.openEndDrawer();
+        break;
+      case _ZikrMenuAction.edit:
+        _toggleEdit();
+        break;
+    }
+  }
+
+  List<Widget> _buildAppBarActions({
+    required String pageTitle,
+    required List<String> tabContents,
+    required int selectedTabIndex,
+    required bool hasAnyContent,
+    required bool isCompact,
+  }) {
+    final settingsButton = IconButton(
+      icon: const Icon(Icons.filter_list),
+      tooltip: 'Reading settings',
+      onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
+    );
+
+    if (zikrData == null) return [settingsButton];
+
+    if (isEditing) {
+      if (!isAdmin) return [settingsButton];
+      return [
+        IconButton(
+          icon: const Icon(Icons.delete),
+          tooltip: 'Delete Zikr',
+          onPressed: _deleteZikr,
+        ),
+        IconButton(
+          icon: const Icon(Icons.done),
+          tooltip: 'Save Changes',
+          onPressed: _saveEdits,
+        ),
+        IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: 'Stop editing',
+          onPressed: _toggleEdit,
+        ),
+      ];
+    }
+
+    final canShare = !_isSharingZikr;
+    return [
+      if (hasAnyContent)
+        IconButton(
+          icon: Icon(
+            _savedBookmark == null ? Icons.bookmark_border : Icons.bookmark,
+          ),
+          tooltip:
+              _savedBookmark == null ? 'Save Bookmark' : 'Remove Bookmark',
+          onPressed: () => _toggleBookmark(
+            pageTitle: pageTitle,
+            tabContents: tabContents,
+            selectedTabIndex: selectedTabIndex,
+          ),
+        ),
+      if (!isCompact)
+        IconButton(
+          icon: const Icon(Icons.share),
+          tooltip: 'Share',
+          onPressed: canShare ? _shareCurrentZikr : null,
+        ),
+      PopupMenuButton<_ZikrMenuAction>(
+        tooltip: 'More options',
+        onSelected: _handleMenuAction,
+        itemBuilder: (context) => [
+          if (isCompact)
+            PopupMenuItem(
+              value: _ZikrMenuAction.share,
+              enabled: canShare,
+              child: const ListTile(
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                leading: Icon(Icons.share),
+                title: Text('Share'),
+              ),
+            ),
+          const PopupMenuItem(
+            value: _ZikrMenuAction.readingSettings,
+            child: ListTile(
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.filter_list),
+              title: Text('Reading settings'),
+            ),
+          ),
+          if (isAdmin)
+            const PopupMenuItem(
+              value: _ZikrMenuAction.edit,
+              child: ListTile(
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                leading: Icon(Icons.edit),
+                title: Text('Edit Zikr'),
+              ),
+            ),
+        ],
+      ),
+    ];
+  }
+
+  PreferredSizeWidget? _buildReadingProgressBar(BuildContext context) {
+    if (!_readingStats.hasContent) return null;
+    if (SP.isInitialized && !(SP.prefs.getBool(showZikrProgressKey) ?? true)) {
+      return null;
+    }
+
+    final foreground = Theme.of(context).appBarTheme.foregroundColor ??
+        Theme.of(context).colorScheme.onSurface;
+    final readingTime = zikrReadingTimeLabel(_readingStats.duration);
+
+    return PreferredSize(
+      preferredSize: const Size.fromHeight(26),
+      child: ValueListenableBuilder<double>(
+        valueListenable: _readingProgress,
+        builder: (context, progress, _) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            LinearProgressIndicator(
+              value: progress,
+              minHeight: 3,
+              backgroundColor: foreground.withValues(alpha: 0.2),
+              valueColor: AlwaysStoppedAnimation<Color>(
+                foreground.withValues(alpha: 0.85),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 3, 16, 4),
+              child: DefaultTextStyle(
+                style: TextStyle(
+                  fontSize: 11,
+                  color: foreground.withValues(alpha: 0.85),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(readingTime),
+                    Text(zikrProgressLabel(progress)),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final merits = meritsController?.text.trim() ?? '';
@@ -930,58 +1171,25 @@ class _ZikrPageState extends State<ZikrPage> with RouteAware {
         tabContents.any((content) => content.trim().isNotEmpty);
     final selectedTabIndex = _clampedSelectedTabIndex(tabContents);
     _scheduleBookmarkHintIfNeeded(hasAnyContent: hasAnyContent);
+    _refreshReadingStats(
+      isEditing ? const [] : tabContents,
+      hideHeaderLine: tabContents.length > 1,
+    );
+    final isCompact = MediaQuery.of(context).size.width < _compactActionsWidth;
 
     return SelectionArea(
       child: Scaffold(
+        key: _scaffoldKey,
         appBar: AppBar(
-          title: Text(pageTitle),
-          actions: [
-            if (isAdmin && zikrData != null && isEditing)
-              IconButton(
-                icon: const Icon(Icons.delete),
-                tooltip: 'Delete Zikr',
-                onPressed: _deleteZikr,
-              ),
-            if (isAdmin && zikrData != null && isEditing)
-              IconButton(
-                icon: const Icon(Icons.done),
-                tooltip: 'Save Changes',
-                onPressed: _saveEdits,
-              ),
-            if (zikrData != null)
-              if (!isEditing && hasAnyContent)
-                IconButton(
-                  icon: Icon(_savedBookmark == null
-                      ? Icons.bookmark_border
-                      : Icons.bookmark),
-                  tooltip: _savedBookmark == null
-                      ? 'Save Bookmark'
-                      : 'Remove Bookmark',
-                  onPressed: () => _toggleBookmark(
-                    pageTitle: pageTitle,
-                    tabContents: tabContents,
-                    selectedTabIndex: selectedTabIndex,
-                  ),
-                ),
-            if (zikrData != null)
-              IconButton(
-                icon: const Icon(Icons.share),
-                tooltip: 'Share',
-                onPressed: _isSharingZikr ? null : _shareCurrentZikr,
-              ),
-            isAdmin && zikrData != null
-                ? IconButton(
-                    icon: Icon(isEditing ? Icons.close : Icons.edit),
-                    onPressed: _toggleEdit,
-                  )
-                : Container(),
-            Builder(builder: (BuildContext innerContext) {
-              return IconButton(
-                icon: Icon(Icons.filter_list),
-                onPressed: () => Scaffold.of(innerContext).openEndDrawer(),
-              );
-            }),
-          ],
+          title: _buildAppBarTitle(pageTitle),
+          actions: _buildAppBarActions(
+            pageTitle: pageTitle,
+            tabContents: tabContents,
+            selectedTabIndex: selectedTabIndex,
+            hasAnyContent: hasAnyContent,
+            isCompact: isCompact,
+          ),
+          bottom: _buildReadingProgressBar(context),
         ),
         endDrawer: ZikrSettingsPage(refreshState),
         floatingActionButton: ValueListenableBuilder<bool>(
@@ -1029,6 +1237,7 @@ class _ZikrPageState extends State<ZikrPage> with RouteAware {
                                     setState(() {
                                       _selectedZikrTabIndex = index;
                                     });
+                                    _updateReadingProgress();
                                   },
                                   hasMerits: hasMerits,
                                   onShowMerits: _showMeritsSheet,

--- a/lib/pages/zikr/zikr_reading_stats.dart
+++ b/lib/pages/zikr/zikr_reading_stats.dart
@@ -1,0 +1,171 @@
+import 'zikr_content_parser.dart';
+
+/// Words an average reciter covers per minute of Arabic supplication text.
+const double _arabicWordsPerMinute = 45;
+
+/// Words per minute used for content that has no Arabic to recite.
+const double _latinWordsPerMinute = 190;
+
+/// Reading effort for a single zikr tab.
+class ZikrTabReadingStats {
+  const ZikrTabReadingStats({
+    required this.arabicWords,
+    required this.latinWords,
+  });
+
+  final int arabicWords;
+  final int latinWords;
+
+  bool get isEmpty => arabicWords == 0 && latinWords == 0;
+
+  /// Transliteration and translation are read alongside the Arabic rather than
+  /// after it, so a tab that has Arabic is timed by its Arabic alone.
+  double get minutes => arabicWords > 0
+      ? arabicWords / _arabicWordsPerMinute
+      : latinWords / _latinWordsPerMinute;
+}
+
+/// Reading effort for every visible tab of a zikr.
+class ZikrReadingStats {
+  const ZikrReadingStats({required this.tabs});
+
+  static const ZikrReadingStats empty = ZikrReadingStats(tabs: []);
+
+  final List<ZikrTabReadingStats> tabs;
+
+  double get totalMinutes =>
+      tabs.fold<double>(0, (total, tab) => total + tab.minutes);
+
+  Duration get duration {
+    final seconds = (totalMinutes * 60).round();
+    return Duration(seconds: seconds < 0 ? 0 : seconds);
+  }
+
+  bool get hasContent => tabs.any((tab) => !tab.isEmpty);
+
+  /// Share of the whole zikr each tab represents, so progress across tabs
+  /// tracks content rather than tab count. Falls back to equal weights when
+  /// nothing can be measured.
+  List<double> get tabWeights {
+    if (tabs.isEmpty) return const [];
+
+    final total = totalMinutes;
+    if (total <= 0) {
+      return List<double>.filled(tabs.length, 1 / tabs.length);
+    }
+    return tabs.map((tab) => tab.minutes / total).toList();
+  }
+}
+
+/// Measures how long the given tabs take to recite.
+///
+/// [hideHeaderLine] mirrors the viewer, which drops the first line of every tab
+/// when it is being rendered as the tab's chip label.
+ZikrReadingStats analyzeZikrReadingStats(
+  List<String> tabContents, {
+  bool hideHeaderLine = false,
+}) {
+  return ZikrReadingStats(
+    tabs: tabContents
+        .map((content) => _analyzeTab(content, hideHeaderLine: hideHeaderLine))
+        .toList(),
+  );
+}
+
+ZikrTabReadingStats _analyzeTab(
+  String content, {
+  required bool hideHeaderLine,
+}) {
+  final lines = content.split('\n');
+  if (hideHeaderLine && lines.isNotEmpty) {
+    lines.removeAt(0);
+  }
+
+  var arabicWords = 0;
+  var latinWords = 0;
+  for (final rawLine in lines) {
+    final line = rawLine.trim();
+    if (line.isEmpty) continue;
+
+    final words = _countWords(line);
+    if (words == 0) continue;
+
+    if (ZikrContentParser.isArabic(line)) {
+      arabicWords += words;
+    } else {
+      latinWords += words;
+    }
+  }
+
+  return ZikrTabReadingStats(
+    arabicWords: arabicWords,
+    latinWords: latinWords,
+  );
+}
+
+int _countWords(String line) {
+  final text = ZikrContentParser.parseLineSegments(line)
+      .map((segment) => segment.text)
+      .join();
+  return text
+      .split(RegExp(r'\s+'))
+      .where((word) => word.trim().isNotEmpty)
+      .length;
+}
+
+/// Fraction of a single tab that has been scrolled past.
+///
+/// A tab that fits on screen has nothing left to scroll, so it counts as read.
+double zikrTabScrollFraction({
+  required double scrollOffset,
+  required double maxScrollExtent,
+}) {
+  if (!maxScrollExtent.isFinite || maxScrollExtent <= 0) return 1;
+  return (scrollOffset / maxScrollExtent).clamp(0.0, 1.0).toDouble();
+}
+
+/// Overall progress through a zikr, weighting each tab by its reading time.
+double zikrReadingProgress({
+  required List<double> tabWeights,
+  required int tabIndex,
+  required double tabFraction,
+}) {
+  if (tabWeights.isEmpty) return 0;
+
+  final index = tabIndex.clamp(0, tabWeights.length - 1);
+  final fraction = tabFraction.clamp(0.0, 1.0).toDouble();
+
+  var completed = 0.0;
+  for (var i = 0; i < index; i++) {
+    completed += tabWeights[i];
+  }
+  completed += tabWeights[index] * fraction;
+
+  final total = tabWeights.fold<double>(0, (sum, weight) => sum + weight);
+  if (total <= 0) return 0;
+
+  return (completed / total).clamp(0.0, 1.0).toDouble();
+}
+
+/// Human readable duration such as `under 1 min`, `8 min` or `1 hr 5 min`.
+String formatZikrDuration(Duration duration) {
+  final totalMinutes = (duration.inSeconds / 60).round();
+  if (totalMinutes < 1) return 'under 1 min';
+  if (totalMinutes < 60) return '$totalMinutes min';
+
+  final hours = totalMinutes ~/ 60;
+  final minutes = totalMinutes % 60;
+  final hourLabel = hours == 1 ? '1 hr' : '$hours hrs';
+  return minutes == 0 ? hourLabel : '$hourLabel $minutes min';
+}
+
+/// Label for the estimated time to recite the whole zikr.
+String zikrReadingTimeLabel(Duration duration) =>
+    '${formatZikrDuration(duration)} read';
+
+/// Label for how far through the zikr the reader is.
+String zikrProgressLabel(double progress) {
+  final clamped = progress.clamp(0.0, 1.0).toDouble();
+  if (clamped >= 0.995) return 'Completed';
+  return '${(clamped * 100).floor()}%';
+}

--- a/lib/widgets/zikr_reading_preferences.dart
+++ b/lib/widgets/zikr_reading_preferences.dart
@@ -6,6 +6,9 @@ import '../constants.dart';
 import '../utils/font_preferences.dart';
 import '../utils/shared_preferences.dart';
 
+/// Preference key controlling the reading progress bar on the zikr page.
+const String showZikrProgressKey = 'show_zikr_progress';
+
 class ZikrReadingPreferencesControls extends StatefulWidget {
   const ZikrReadingPreferencesControls({
     Key? key,
@@ -82,6 +85,15 @@ class _ZikrReadingPreferencesControlsState
             await _saveBooleanPref("keep_awake", v);
           },
           title: const Text("Keep screen on while reciting Zikr"),
+        ),
+        SwitchListTile(
+          secondary: _leading(Icons.timelapse),
+          value: SP.prefs.getBool(showZikrProgressKey) ?? true,
+          onChanged: (v) async {
+            await _saveBooleanPref(showZikrProgressKey, v);
+          },
+          title: const Text("Show Reading Progress"),
+          subtitle: const Text("Progress bar and estimated reading time."),
         ),
         SwitchListTile(
           secondary: _leading(Icons.ios_share),

--- a/test/zikr_content_progress_test.dart
+++ b/test/zikr_content_progress_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shia_companion/pages/zikr/zikr_content_viewer.dart';
+
+void main() {
+  testWidgets('reports scroll metrics before the reader scrolls',
+      (tester) async {
+    final positions = <ZikrContentScrollPosition>[];
+    await _pumpViewer(tester, _longContent(), positions.add);
+
+    expect(positions, isNotEmpty);
+    expect(positions.last.tabIndex, 0);
+    expect(positions.last.scrollOffset, 0);
+    expect(positions.last.maxScrollExtent, greaterThan(0));
+  });
+
+  testWidgets('reports the offset and extent while scrolling',
+      (tester) async {
+    final positions = <ZikrContentScrollPosition>[];
+    await _pumpViewer(tester, _longContent(), positions.add);
+
+    await tester.drag(find.byType(ListView), const Offset(0, -200));
+    await tester.pumpAndSettle();
+
+    expect(positions.last.scrollOffset, greaterThan(0));
+    expect(
+      positions.last.scrollOffset,
+      lessThanOrEqualTo(positions.last.maxScrollExtent),
+    );
+  });
+
+  testWidgets('content that fits reports nothing left to scroll',
+      (tester) async {
+    final positions = <ZikrContentScrollPosition>[];
+    await _pumpViewer(tester, 'اللهم صل على محمد', positions.add);
+
+    expect(positions.last.maxScrollExtent, 0);
+  });
+}
+
+String _longContent() =>
+    List.generate(80, (index) => 'اللهم صل على محمد وآل محمد').join('\n');
+
+Future<void> _pumpViewer(
+  WidgetTester tester,
+  String content,
+  ValueChanged<ZikrContentScrollPosition> onPosition,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: ZikrContentViewerWidget(
+          tabContents: <String>[content],
+          selectedTabIndex: 0,
+          onTabChanged: (_) {},
+          hasMerits: false,
+          onShowMerits: () {},
+          onLinkTap: (_) async {},
+          onScrollPositionChanged: onPosition,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}

--- a/test/zikr_reading_stats_test.dart
+++ b/test/zikr_reading_stats_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shia_companion/pages/zikr/zikr_reading_stats.dart';
+
+/// `words` Arabic words on a single line.
+String _arabicLine(int words) => List.filled(words, 'اللهم').join(' ');
+
+/// `words` Latin words on a single line.
+String _latinLine(int words) => List.filled(words, 'word').join(' ');
+
+void main() {
+  group('analyzeZikrReadingStats', () {
+    test('times Arabic tabs by their Arabic words alone', () {
+      final stats = analyzeZikrReadingStats([
+        '${_arabicLine(45)}\n${_latinLine(200)}',
+      ]);
+
+      expect(stats.hasContent, isTrue);
+      expect(stats.tabs.single.arabicWords, 45);
+      expect(stats.tabs.single.latinWords, 200);
+      expect(stats.duration, const Duration(minutes: 1));
+    });
+
+    test('falls back to reading speed when a tab has no Arabic', () {
+      final stats = analyzeZikrReadingStats([_latinLine(190)]);
+
+      expect(stats.tabs.single.arabicWords, 0);
+      expect(stats.duration, const Duration(minutes: 1));
+    });
+
+    test('drops the header line when it is shown as a tab chip', () {
+      final stats = analyzeZikrReadingStats(
+        ['Part one\n${_arabicLine(45)}'],
+        hideHeaderLine: true,
+      );
+
+      expect(stats.tabs.single.latinWords, 0);
+      expect(stats.tabs.single.arabicWords, 45);
+    });
+
+    test('counts markdown link labels but not their targets', () {
+      final stats = analyzeZikrReadingStats(
+        ['Read [the full source](https://example.com/a/very/long/path)'],
+      );
+
+      expect(stats.tabs.single.latinWords, 4);
+    });
+
+    test('reports no content for blank tabs', () {
+      final stats = analyzeZikrReadingStats(['', '   \n\n']);
+
+      expect(stats.hasContent, isFalse);
+      expect(stats.duration, Duration.zero);
+    });
+
+    test('weights tabs by their share of the reciting time', () {
+      final stats = analyzeZikrReadingStats([
+        _arabicLine(30),
+        _arabicLine(10),
+      ]);
+
+      expect(stats.tabWeights, [closeTo(0.75, 0.0001), closeTo(0.25, 0.0001)]);
+    });
+
+    test('weights empty tabs equally instead of dividing by zero', () {
+      final stats = analyzeZikrReadingStats(['', '']);
+
+      expect(stats.tabWeights, [0.5, 0.5]);
+    });
+
+    test('has no weights without tabs', () {
+      expect(ZikrReadingStats.empty.tabWeights, isEmpty);
+      expect(ZikrReadingStats.empty.hasContent, isFalse);
+    });
+  });
+
+  group('zikrTabScrollFraction', () {
+    test('treats content that fits on screen as fully read', () {
+      expect(
+        zikrTabScrollFraction(scrollOffset: 0, maxScrollExtent: 0),
+        1,
+      );
+    });
+
+    test('reports the scrolled share and clamps overscroll', () {
+      expect(
+        zikrTabScrollFraction(scrollOffset: 50, maxScrollExtent: 200),
+        0.25,
+      );
+      expect(
+        zikrTabScrollFraction(scrollOffset: -30, maxScrollExtent: 200),
+        0,
+      );
+      expect(
+        zikrTabScrollFraction(scrollOffset: 260, maxScrollExtent: 200),
+        1,
+      );
+    });
+  });
+
+  group('zikrReadingProgress', () {
+    test('counts earlier tabs as complete', () {
+      expect(
+        zikrReadingProgress(
+          tabWeights: const [0.75, 0.25],
+          tabIndex: 1,
+          tabFraction: 0.5,
+        ),
+        closeTo(0.875, 0.0001),
+      );
+    });
+
+    test('scales the current tab by its own weight', () {
+      expect(
+        zikrReadingProgress(
+          tabWeights: const [0.75, 0.25],
+          tabIndex: 0,
+          tabFraction: 0.5,
+        ),
+        closeTo(0.375, 0.0001),
+      );
+    });
+
+    test('clamps an out of range tab index', () {
+      expect(
+        zikrReadingProgress(
+          tabWeights: const [1],
+          tabIndex: 4,
+          tabFraction: 1,
+        ),
+        1,
+      );
+    });
+
+    test('is zero without tabs', () {
+      expect(
+        zikrReadingProgress(tabWeights: const [], tabIndex: 0, tabFraction: 1),
+        0,
+      );
+    });
+  });
+
+  group('labels', () {
+    test('formats durations for the reader', () {
+      expect(formatZikrDuration(const Duration(seconds: 20)), 'under 1 min');
+      expect(formatZikrDuration(const Duration(minutes: 8)), '8 min');
+      expect(formatZikrDuration(const Duration(minutes: 60)), '1 hr');
+      expect(formatZikrDuration(const Duration(minutes: 65)), '1 hr 5 min');
+      expect(formatZikrDuration(const Duration(minutes: 125)), '2 hrs 5 min');
+    });
+
+    test('labels the reading time estimate', () {
+      expect(
+        zikrReadingTimeLabel(const Duration(minutes: 3)),
+        '3 min read',
+      );
+    });
+
+    test('rounds progress down until the zikr is finished', () {
+      expect(zikrProgressLabel(0), '0%');
+      expect(zikrProgressLabel(0.339), '33%');
+      expect(zikrProgressLabel(0.98), '98%');
+      expect(zikrProgressLabel(1), 'Completed');
+    });
+  });
+}


### PR DESCRIPTION
Long dua titles were being squeezed out by a five-icon action row. Share,
edit and reading settings now live in an overflow menu (share stays inline
on wider screens), and titles longer than a short line wrap onto a second,
smaller line instead of being clipped.

The app bar also carries a slim progress bar with the estimated recitation
time and percent completed. Progress is weighted by each tab's share of the
reciting time, so multi-part duas advance realistically, and the estimate
times Arabic at reciting speed rather than counting the translation twice.
The bar can be turned off from the reading settings drawer.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019PsFqK2siSvFjqRvpfztZX