### PR TITLE
Surface deployed URLs on the run page and document the preview channels

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -43,6 +43,7 @@ jobs:
       # master gets a stable, long-lived channel so there is always somewhere
       # to check the current state of the branch before cutting a release.
       - name: Deploy master to the staging channel
+        id: staging
         if: github.ref == 'refs/heads/master'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -54,6 +55,7 @@ jobs:
           expires: 30d
 
       - name: Deploy pull request preview
+        id: preview
         if: github.event_name == 'pull_request'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -62,3 +64,24 @@ jobs:
           projectId: shia-comapnion
           target: shia-companion
           expires: 7d
+
+      # Put the URL on the run page itself. Otherwise finding where a build
+      # went means digging through step logs or reaching for the Firebase CLI,
+      # and the channel hash is not something anyone should have to memorise.
+      - name: Publish the deployed URL to the run summary
+        if: always() && (steps.staging.outputs.details_url || steps.preview.outputs.details_url)
+        env:
+          # Quoted: an unquoted '#' would start a YAML comment and truncate the
+          # expression mid-way.
+          CHANNEL: "${{ github.ref == 'refs/heads/master' && 'staging' || format('pull request #{0}', github.event.number) }}"
+          URL: "${{ steps.staging.outputs.details_url || steps.preview.outputs.details_url }}"
+          EXPIRES: "${{ steps.staging.outputs.expire_time_formatted || steps.preview.outputs.expire_time_formatted }}"
+        run: |
+          {
+            echo "### Deployed to ${CHANNEL}"
+            echo
+            echo "${URL}"
+            echo
+            echo "Expires: ${EXPIRES:-unknown}"
+          } >> "$GITHUB_STEP_SUMMARY"
+

--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -78,6 +78,7 @@ jobs:
           build-dir: build/web
 
       - name: Deploy to live
+        id: live
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
@@ -85,3 +86,15 @@ jobs:
           projectId: shia-comapnion
           target: shia-companion
           channelId: live
+
+      - name: Publish the deployed URL to the run summary
+        if: always() && steps.live.outputs.details_url
+        env:
+          TAG: "${{ github.event.inputs.ref || github.ref_name }}"
+          URL: "${{ steps.live.outputs.details_url }}"
+        run: |
+          {
+            echo "### Released ${TAG} to production"
+            echo
+            echo "${URL}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -30,6 +30,40 @@ only then deploys to `live`.
 
 **Rolling back** is dispatching `web-release.yml` manually against an older tag.
 
+## Where to test changes before releasing
+
+| Channel | URL | Updated by | Lifetime |
+| --- | --- | --- | --- |
+| `live` | https://shia-companion.web.app | a `v*` tag | permanent |
+| `staging` | https://shia-companion--staging-3dxo2xwu.web.app | every merge to `master` | 30 days, reset on each deploy |
+| per-PR | posted as a comment on the pull request | every push to the PR | 7 days |
+
+`staging` is the one to check before cutting a release: it always holds what is
+currently on `master`.
+
+Every deploy also prints its URL to the **run summary**, at the top of the
+workflow run page in the Actions tab. That is the quickest place to look and it
+is always correct, which a bookmark is not — see the caveat below.
+
+To list the channels directly:
+
+```bash
+firebase hosting:channel:list --site shia-companion --project shia-comapnion
+```
+
+`--site` is **not optional**. The project id is misspelled (`shia-comapnion`)
+but the site is not (`shia-companion`), and without `--site` the CLI queries a
+near-empty site of the same name as the project and reports a stale `live` row
+and no preview channels at all. Same distinction in the console:
+https://console.firebase.google.com/project/shia-comapnion/hosting/sites/shia-companion
+
+**The staging URL is stable, but not permanent.** The hash belongs to the
+channel rather than to any single deploy, so redeploying does not change it.
+Preview channels are capped at a 30-day expiry by Firebase, and this one's
+clock resets on every merge to `master`. If `master` goes untouched for longer
+than that, Firebase deletes the channel and the next merge recreates it —
+expect a new hash then, and prefer the run summary over a bookmark.
+
 ## Testing layers
 
 Three layers, each catching what the others cannot.


### PR DESCRIPTION
Follow-up to #29. Two small things, both about finding where a build went.

## The URL now appears on the run page

Each deploy writes its URL to the workflow run summary, so it is a clickable line at the top of the Actions run rather than something buried in step logs. Uses the deploy action's `details_url` output — added to `web-preview.yml` (staging and per-PR) and `web-release.yml` (production).

## Documented the channels

New section in `docs/CI.md`:

| Channel | URL | Updated by | Lifetime |
| --- | --- | --- | --- |
| `live` | https://shia-companion.web.app | a `v*` tag | permanent |
| `staging` | https://shia-companion--staging-3dxo2xwu.web.app | every merge to `master` | 30 days, reset on each deploy |
| per-PR | commented on the PR | every push to the PR | 7 days |

**`staging` is the one to check before cutting a release.**

It also records the CLI incantation and the trap in it:

```bash
firebase hosting:channel:list --site shia-companion --project shia-comapnion
```

`--site` is not optional. The project id is misspelled (`shia-comapnion`) but the site is not (`shia-companion`). Without it the CLI queries a near-empty site named after the project and reports a stale `live` row and no preview channels — which reads convincingly like staging was never created. It cost me a wrong conclusion earlier today.

Finally, a note that the staging hash is stable across redeploys but not across expiry, so the run summary is the reliable reference rather than a bookmark.

## Verification

All three workflows parse, and I checked the `format('pull request #{0}', …)` expression survives YAML parsing — an unquoted `#` starts a comment there and silently truncated the expression on the first attempt. Caught by the editor's linter, fixed by quoting, and confirmed intact after parsing.

The run-summary steps themselves only execute on a real deploy, so they are exercised the first time this lands on `master`.

---
_Generated by [Claude Code](https://claude.ai/code)_
