### PR TITLE
Add SEO validation tests and improve sitemap generation

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -30,6 +30,36 @@ only then deploys to `live`.
 
 **Rolling back** is dispatching `web-release.yml` manually against an older tag.
 
+**Nothing reaches production until a tag is pushed.** Merging to `master` moves
+`staging` and nothing else, so `https://shia-companion.web.app` can sit many
+merges behind `master` without anything looking wrong. This matters most for
+SEO: the pre-rendered `/zikr/<slug>` pages and the generated `sitemap.xml` only
+exist in a deployed bundle, so until a release tag ships them, Search Console
+keeps crawling the previous sitemap. Check the `live` row of
+`firebase hosting:channel:list` against the tag you expect before concluding
+anything about what Google can see.
+
+## SEO surface
+
+Three things have to line up, and all three ship in the same bundle:
+
+| File | Where it comes from |
+| --- | --- |
+| `sitemap.xml` | generated into `build/web` by `scripts/generate_zikr_seo_pages.js`; `web/sitemap.xml` is only the fallback |
+| `/zikr/<slug>/index.html` | same script, one pre-rendered page per zikr |
+| `robots.txt` | checked in at `web/robots.txt`, points at `SITE_ORIGIN/sitemap.xml` |
+
+`test_visual/specs/seo.spec.js` asserts all of it against the built bundle.
+The failure it exists to catch is quiet: if `sitemap.xml` is missing from
+`build/web`, the `**` rewrite in `firebase.json` answers with the app shell
+while the `headers` rule still labels it `application/xml`. That is a 200 no
+crawler can parse, and Search Console reports it as **"Couldn't fetch"** — which
+reads like a network problem and is not one.
+
+Every `<loc>` must resolve to a real file in the bundle. A path that exists only
+through the rewrite returns the same app shell as every other such path, so
+Google folds it into the home page instead of indexing it.
+
 ## Where to test changes before releasing
 
 | Channel | URL | Updated by | Lifetime |

--- a/scripts/generate_zikr_seo_pages.js
+++ b/scripts/generate_zikr_seo_pages.js
@@ -13,6 +13,14 @@ const SITE_ORIGIN = (process.env.SITE_ORIGIN || 'https://shia-companion.web.app'
   .replace(/\/+$/, '');
 const MAX_SECTION_LINES = 80;
 
+// Hand-written pages that ship from web/ rather than being generated here.
+// This file replaces the checked-in sitemap wholesale, so anything left out
+// disappears from the sitemap the moment the generator runs. Only real files
+// belong here: a path that exists solely through the "**" rewrite in
+// firebase.json resolves to the app shell, which Google sees as a duplicate of
+// the home page and drops.
+const STATIC_PAGE_PATHS = ['/privacy.html', '/delete_account.html'];
+
 function escapeHtml(value) {
   return `${value ?? ''}`
     .replace(/&/g, '&amp;')
@@ -288,7 +296,16 @@ function buildPageHtml(templateHtml, page) {
 }
 
 function buildSitemap(paths) {
-  const urls = ['/', '/zikr', ...paths].map((urlPath) => `${SITE_ORIGIN}${urlPath}`);
+  const allPaths = ['/', '/zikr', ...STATIC_PAGE_PATHS, ...paths];
+  const seen = new Set();
+  for (const urlPath of allPaths) {
+    if (seen.has(urlPath)) {
+      throw new Error(`Duplicate sitemap path: ${urlPath}`);
+    }
+    seen.add(urlPath);
+  }
+
+  const urls = allPaths.map((urlPath) => `${SITE_ORIGIN}${urlPath}`);
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
@@ -344,7 +361,15 @@ function main() {
     );
   }
 
-  const templateHtml = fs.readFileSync(FLUTTER_INDEX_PATH, 'utf8');
+  // `flutter build web` substitutes $FLUTTER_BASE_HREF only in the root
+  // index.html it emits; a copy of the template placed in a subdirectory keeps
+  // the literal placeholder. That ships a page whose <base> is an invalid URL,
+  // so every relative asset — flutter_bootstrap.js included — fails to load and
+  // the page never boots. It only bites when the generator runs against the
+  // web/ source tree, which the pre-push hook does. Pin it to the site root.
+  const templateHtml = fs
+    .readFileSync(FLUTTER_INDEX_PATH, 'utf8')
+    .replace(/\$FLUTTER_BASE_HREF/g, '/');
   const index = readJson(ZIKR_INDEX_PATH);
   const pages = [];
   const slugs = new Map();
@@ -401,11 +426,8 @@ function main() {
     }
   }
 
-  fs.writeFileSync(
-    path.join(BUILD_WEB_DIR, 'sitemap.xml'),
-    buildSitemap(pages.map((page) => page.canonicalPath)),
-    'utf8',
-  );
+  const sitemap = buildSitemap(pages.map((page) => page.canonicalPath));
+  fs.writeFileSync(path.join(BUILD_WEB_DIR, 'sitemap.xml'), sitemap, 'utf8');
   fs.writeFileSync(
     path.join(GENERATED_ZIKR_DIR, 'index.html'),
     buildZikrIndexPage(templateHtml, pages),
@@ -414,7 +436,9 @@ function main() {
 
   console.log(`Generated ${pages.length} zikr SEO pages in ${GENERATED_ZIKR_DIR}`);
   console.log(`Generated ${aliasCount} zikr alias pages`);
-  console.log(`Generated sitemap.xml with ${pages.length + 2} URLs`);
+  console.log(
+    `Generated sitemap.xml with ${(sitemap.match(/<loc>/g) ?? []).length} URLs`,
+  );
 }
 
 main();

--- a/test_visual/serve.js
+++ b/test_visual/serve.js
@@ -87,9 +87,15 @@ const server = http.createServer((req, res) => {
   }
 
   // firebase.json: { "source": "**", "destination": "/index.html" }
+  //
+  // Hosting matches `headers` against the *requested* path, before the rewrite,
+  // so a missing /sitemap.xml comes back as the app shell still labelled
+  // application/xml. That is a 200 no crawler can parse, and it is exactly the
+  // shape of failure the SEO tests exist to catch — so mirror it here rather
+  // than quietly serving the fallback as text/html.
   const fallback = path.join(ROOT, 'index.html');
   if (fs.existsSync(fallback)) {
-    send(res, 200, fallback);
+    send(res, 200, fallback, FORCED_CONTENT_TYPES.get(pathname));
     return;
   }
 

--- a/test_visual/specs/seo.spec.js
+++ b/test_visual/specs/seo.spec.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {test, expect} = require('@playwright/test');
+const {BUILD_DIR, sampleGeneratedZikrPages} = require('./helpers');
+
+// The origin baked into the generated sitemap. Matches the default in
+// scripts/generate_zikr_seo_pages.js and the site-origin input on the
+// build-web action.
+const SITE_ORIGIN = (process.env.SITE_ORIGIN || 'https://shia-companion.web.app')
+  .replace(/\/+$/, '');
+
+// These checks run against the built bundle, not the rendered app, so one
+// project is enough — the other would assert identical bytes.
+test.beforeEach(({}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop');
+});
+
+function locsFrom(xml) {
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+}
+
+/**
+ * Resolves a sitemap path the way Firebase Hosting does when it looks for a
+ * real file: exact match first, then <path>/index.html. Returns null when only
+ * the "**" rewrite could serve it.
+ */
+function resolveBundleFile(urlPath) {
+  const relative = urlPath.replace(/^\/+/, '');
+  const candidates = relative === ''
+    ? ['index.html']
+    : [relative, path.join(relative, 'index.html')];
+
+  for (const candidate of candidates) {
+    const filePath = path.join(BUILD_DIR, candidate);
+    if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+      return filePath;
+    }
+  }
+  return null;
+}
+
+test.describe('sitemap.xml', () => {
+  test('is served as parseable XML rather than the app shell', async ({request}) => {
+    const response = await request.get('/sitemap.xml');
+    expect(response.status()).toBe(200);
+
+    const contentType = response.headers()['content-type'] ?? '';
+    expect(contentType, 'firebase.json pins this to application/xml').toContain('xml');
+
+    const body = await response.text();
+    // The failure this guards: sitemap.xml missing from build/web, so the
+    // rewrite returns index.html under an XML content type. Search Console
+    // reports that as "Couldn't fetch", which reads like a network problem and
+    // is not one.
+    expect(
+      body.toLowerCase(),
+      'sitemap.xml is serving the Flutter app shell — it is missing from the bundle',
+    ).not.toContain('<!doctype html');
+    expect(body.trimStart()).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    expect(body).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(body.trimEnd().endsWith('</urlset>')).toBe(true);
+  });
+
+  test('lists every generated zikr page exactly once', async ({request}) => {
+    const locs = locsFrom(await (await request.get('/sitemap.xml')).text());
+
+    expect(new Set(locs).size, 'duplicate <loc> entries').toBe(locs.length);
+    expect(locs.length).toBeLessThanOrEqual(50000);
+    for (const loc of locs) {
+      expect(loc, 'every <loc> must be absolute and on the production origin')
+        .toMatch(new RegExp(`^${SITE_ORIGIN}/`));
+    }
+
+    const generated = sampleGeneratedZikrPages(Number.MAX_SAFE_INTEGER);
+    expect(
+      generated.length,
+      'no pre-rendered zikr pages in the bundle — the generator did not target build/web',
+    ).toBeGreaterThan(0);
+
+    // Compare on canonical URL rather than directory name. Alias directories
+    // are deliberately absent from the sitemap: each one self-canonicalises to
+    // the slug it duplicates, so listing it would submit the same page twice.
+    for (const slug of generated) {
+      const html = fs.readFileSync(
+        path.join(BUILD_DIR, 'zikr', slug, 'index.html'),
+        'utf8',
+      );
+      const canonical = html.match(/<link rel="canonical" href="([^"]+)">/)?.[1];
+      expect(canonical, `zikr/${slug} has no canonical link`).toBeTruthy();
+      expect(locs, `zikr/${slug} canonicalises to a URL missing from the sitemap`)
+        .toContain(canonical);
+    }
+
+    expect(locs).toContain(`${SITE_ORIGIN}/`);
+    expect(locs).toContain(`${SITE_ORIGIN}/privacy.html`);
+    expect(locs).toContain(`${SITE_ORIGIN}/delete_account.html`);
+  });
+
+  test('points only at paths backed by a real file in the bundle', async ({request}) => {
+    const locs = locsFrom(await (await request.get('/sitemap.xml')).text());
+
+    const rewriteOnly = locs
+      .map((loc) => loc.slice(SITE_ORIGIN.length) || '/')
+      .filter((urlPath) => resolveBundleFile(urlPath) === null);
+
+    // A path served only by the "**" rewrite returns the app shell: identical
+    // bytes for every such URL, which Google folds into the home page instead
+    // of indexing.
+    expect(
+      rewriteOnly,
+      'these sitemap URLs have no file in the bundle and resolve to the app shell',
+    ).toEqual([]);
+  });
+});
+
+test('robots.txt allows crawling and advertises the sitemap', async ({request}) => {
+  const response = await request.get('/robots.txt');
+  expect(response.status()).toBe(200);
+
+  const body = await response.text();
+  expect(body).toMatch(/^\s*User-agent:\s*\*/m);
+  expect(body, 'a bare "Disallow: /" hides the whole site')
+    .not.toMatch(/^\s*Disallow:\s*\/\s*$/m);
+  expect(body).toContain(`Sitemap: ${SITE_ORIGIN}/sitemap.xml`);
+});
+
+test('generated pages carry a substituted <base href>', () => {
+  const slugs = sampleGeneratedZikrPages();
+  expect(slugs.length).toBeGreaterThan(0);
+
+  for (const slug of slugs) {
+    const html = fs.readFileSync(
+      path.join(BUILD_DIR, 'zikr', slug, 'index.html'),
+      'utf8',
+    );
+    // An unsubstituted placeholder makes <base> an invalid URL, so every
+    // relative asset on the page — flutter_bootstrap.js included — 404s.
+    expect(html, `zikr/${slug} kept the literal $FLUTTER_BASE_HREF placeholder`)
+      .not.toContain('$FLUTTER_BASE_HREF');
+    // Alias directories canonicalise to the slug they duplicate, so match the
+    // shape rather than the directory name.
+    expect(html).toMatch(
+      new RegExp(`<link rel="canonical" href="${SITE_ORIGIN}/zikr/[a-z0-9-]+">`),
+    );
+  }
+});

--- a/web/index.html
+++ b/web/index.html
@@ -13,6 +13,10 @@
   <meta property="og:description" content="Explore duas, ziyarats, and prayer times for Shia Muslims.">
   <meta property="og:url" content="https://shia-companion.web.app/">
   <meta property="og:type" content="website">
+  <!-- Absolute, so /index.html and the preview-channel hostnames all point at
+       the one production URL instead of competing with it in the index. The
+       generated zikr pages replace this with their own canonical. -->
+  <link rel="canonical" href="https://shia-companion.web.app/">
 
   <!-- iOS/Android web app meta tags -->
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fallback only. scripts/generate_zikr_seo_pages.js overwrites this file in
+  build/web with the full sitemap, including every pre-rendered /zikr/<slug>
+  page. If a deploy ever serves this version instead, the generator did not run
+  against build/web and the zikr pages are missing from the bundle too.
+
+  Every <loc> here must be a real file in the bundle. Paths that exist only via
+  the "**" rewrite in firebase.json return the app shell, which Google indexes
+  as a duplicate of the home page.
+-->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://shia-companion.web.app/</loc>
-    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://shia-companion.web.app/privacy.html</loc>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://shia-companion.web.app/delete-account</loc>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://shia-companion.web.app/delete_account.html</loc>
-    <priority>0.7</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
This PR adds comprehensive SEO testing and improves the sitemap generation process to ensure search engines can properly crawl and index the site. It includes new test coverage for sitemap validity, robots.txt configuration, and pre-rendered page integrity.

## Key Changes

- **New SEO test suite** (`test_visual/specs/seo.spec.js`): Validates that:
  - `sitemap.xml` is served as valid XML (not the app shell)
  - All generated zikr pages are listed exactly once with correct canonical URLs
  - Every sitemap URL points to a real file in the bundle (not just rewrite-only paths)
  - `robots.txt` allows crawling and advertises the sitemap
  - Generated pages have substituted `<base href>` values

- **Improved sitemap generation** (`scripts/generate_zikr_seo_pages.js`):
  - Added `STATIC_PAGE_PATHS` constant to explicitly include `/privacy.html` and `/delete_account.html`
  - Fixed `$FLUTTER_BASE_HREF` placeholder substitution in generated pages (was causing asset 404s)
  - Added duplicate path detection in sitemap building
  - Improved sitemap URL counting in console output

- **Updated fallback sitemap** (`web/sitemap.xml`):
  - Added documentation explaining it's a fallback only
  - Removed priority attributes (not needed for fallback)
  - Fixed `/delete-account` → `/delete_account.html` path

- **Enhanced local test server** (`test_visual/serve.js`):
  - Now mirrors Firebase Hosting behavior: missing files served via rewrite return app shell with forced content type
  - Allows SEO tests to catch the "200 with unparseable XML" failure mode

- **Added canonical link** (`web/index.html`):
  - Home page now includes canonical link to production URL
  - Ensures generated zikr pages don't compete with home page in search index

- **Documentation** (`docs/CI.md`):
  - Added explanation of SEO surface and deployment requirements
  - Clarified that nothing reaches production until a tag is pushed
  - Documented the three components that must align: sitemap, pre-rendered pages, and robots.txt

## Notable Implementation Details

The test suite specifically guards against a subtle failure mode: when `sitemap.xml` is missing from the built bundle, Firebase Hosting's `**` rewrite serves the app shell while the `headers` rule still labels it `application/xml`. This returns a 200 that no crawler can parse, and Search Console reports it as "Couldn't fetch" — appearing like a network problem when it's actually a missing file.

Every `<loc>` in the sitemap must resolve to a real file; paths existing only through rewrites return the app shell, which Google indexes as a duplicate of the home page and drops.

https://claude.ai/code/session_01Nn25xGjoD9ngbiK7s9ivTs