### PR TITLE
Render every menu screen in tests, and fix the ripple Settings hid

### DIFF
--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -336,11 +336,16 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
             ),
           ),
-          Container(
-            decoration: BoxDecoration(
-              color: theme.cardColor,
+          // Material rather than a decorated Container: the rows inside are
+          // ListTiles, which paint their background and ink splashes onto the
+          // nearest Material ancestor. Behind a coloured Container those
+          // effects are hidden, so taps landed with no ripple.
+          Material(
+            color: theme.cardColor,
+            clipBehavior: Clip.antiAlias,
+            shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(8),
-              border: Border.all(
+              side: BorderSide(
                 color: theme.dividerColor.withValues(alpha: 0.28),
               ),
             ),

--- a/test/ui/firebase_test_doubles.dart
+++ b/test/ui/firebase_test_doubles.dart
@@ -1,0 +1,71 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Stands up enough of Firebase for a screen to be rendered.
+///
+/// Screens reach Firebase in two distinct ways, and both have to be answered or
+/// the widget under test never gets as far as laying out:
+///
+///   * Construction. `FavoritesManager` and `QazaTrackerManager` hold
+///     `FirebaseFirestore.instance`, `FirebaseAuth.instance` and
+///     `FirebaseDatabase.instance` in field initialisers, and `ItemList` builds
+///     a collection reference the same way. Every one of those throws
+///     `[core/no-app]` until an app exists, which is what
+///     [setupFirebaseCoreMocks] plus `Firebase.initializeApp` provides.
+///   * Calls. Screens then read from those instances, usually unawaited from
+///     `initState`. With no plugin behind the channel the call raises
+///     `MissingPluginException`, which surfaces as an unhandled async error and
+///     fails the test for a reason that has nothing to do with rendering.
+///
+/// The handlers below answer the second case with empty data, so a screen
+/// renders its "nothing here yet" state — which is the state worth having a
+/// render test for anyway, since it is what a new user sees.
+Future<void> setUpFirebaseForRenderTests() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setupFirebaseCoreMocks();
+  await Firebase.initializeApp();
+  _silenceFirebaseChannels();
+}
+
+/// Channels whose absence would otherwise raise MissingPluginException.
+///
+/// Each returns the emptiest well-formed answer the plugin will accept rather
+/// than throwing, so callers take their "no data" path.
+const Map<String, Object?> _emptyResponses = <String, Object?>{
+  // cloud_firestore
+  'Query#get': <String, Object?>{'documents': [], 'metadatas': []},
+  'DocumentReference#get': <String, Object?>{'data': null, 'metadata': null},
+  'DocumentReference#set': null,
+  'DocumentReference#update': null,
+  'Firestore#enableNetwork': null,
+  'Firestore#disableNetwork': null,
+  // firebase_auth
+  'Auth#registerIdTokenListener': null,
+  'Auth#registerAuthStateListener': null,
+  'Auth#signInAnonymously': null,
+  // firebase_database
+  'DatabaseReference#get': <String, Object?>{'snapshot': null},
+  'DatabaseReference#once': <String, Object?>{'snapshot': null},
+};
+
+void _silenceFirebaseChannels() {
+  const channels = <String>[
+    'plugins.flutter.io/firebase_core',
+    'plugins.flutter.io/firebase_auth',
+    'plugins.flutter.io/firebase_firestore',
+    'plugins.flutter.io/firebase_database',
+    'plugins.flutter.io/firebase_analytics',
+  ];
+
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  for (final name in channels) {
+    messenger.setMockMethodCallHandler(
+      MethodChannel(name, const StandardMethodCodec()),
+      (call) async => _emptyResponses[call.method],
+    );
+  }
+}

--- a/test/ui/page_render_test.dart
+++ b/test/ui/page_render_test.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shia_companion/navigation/home_menu.dart';
 import 'package:shia_companion/pages/about_page.dart';
-import 'package:shia_companion/pages/calendar_page.dart';
-import 'package:shia_companion/pages/flights_page.dart';
+import 'package:shia_companion/utils/dark_mode.dart';
 import 'package:shia_companion/utils/shared_preferences.dart';
-import 'package:shia_companion/widgets/tasbeeh_widget.dart';
 
-/// Renders each screen across the viewports and themes we ship to, and fails on
-/// any framework error raised while laying it out.
+import 'firebase_test_doubles.dart';
+
+/// Renders every screen across the viewports and themes we ship to, and fails
+/// on any framework error raised while laying it out.
 ///
 /// This is the cheap half of "did the UI break". A RenderFlex overflow, a null
 /// dereference during build or a bad constraint all surface here as an
@@ -16,19 +18,15 @@ import 'package:shia_companion/widgets/tasbeeh_widget.dart';
 /// maintain. Pixel-level regressions on the web build are covered separately by
 /// the Playwright suite in test_visual/.
 ///
-/// Adding a screen: append it to [_screens]. Screens that reach Firebase while
-/// building cannot be listed until the suite stands up Firebase test doubles —
-/// that rules out anything using FavoritesManager or QazaTrackerManager, which
-/// hold Firestore and Auth instances as fields, and ItemList, which constructs
-/// a Firestore collection reference in a field initializer. See docs/CI.md.
+/// The screen list is [homeMenuItems] itself rather than a copy, so a new menu
+/// entry is covered the day it is added and cannot be forgotten here.
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   setUpAll(() async {
     // The app initialises SP before runApp; screens read SP.prefs directly and
     // it throws when unset.
     SharedPreferences.setMockInitialValues({});
     await SP.init();
+    await setUpFirebaseForRenderTests();
   });
 
   for (final screen in _screens) {
@@ -53,14 +51,10 @@ void main() {
 }
 
 class _Screen {
-  const _Screen(this.name, this.build, {this.ownsScaffold = true});
+  const _Screen(this.name, this.build);
 
   final String name;
   final Widget Function() build;
-
-  /// False for screens that are page bodies rather than whole pages, and so
-  /// need a Scaffold above them to supply Material and bounded constraints.
-  final bool ownsScaffold;
 }
 
 class _Viewport {
@@ -70,17 +64,21 @@ class _Viewport {
   final Size size;
 }
 
-// trackScreenOnInit is disabled where the screen exposes it so the tests do not
-// depend on analytics being reachable.
+/// Menu screens that cannot be rendered in a widget test, with the reason.
+///
+/// Qibla Finder is a host for a `WebViewWidget`, which asserts unless a
+/// `WebViewPlatform` is registered. Standing one up means implementing the
+/// controller, widget, navigation delegate and cookie manager interfaces — at
+/// which point the test exercises those stubs rather than the screen, since
+/// the screen is little more than a Scaffold around the web view.
+const Set<String> _unrenderableMenuScreens = {'Qibla Finder'};
+
 final List<_Screen> _screens = [
+  for (final item in homeMenuItems)
+    if (!_unrenderableMenuScreens.contains(item.label))
+      _Screen(item.label, item.buildPage),
+  // Reachable from the app bar rather than the menu.
   _Screen('About', () => AboutPage()),
-  _Screen(
-    'Calendar',
-    () => const CalendarPage(trackScreenOnInit: false),
-    ownsScaffold: false,
-  ),
-  _Screen('Flights', () => const FlightsPage(trackScreenOnInit: false)),
-  _Screen('Tasbeeh counter', () => const TasbeehWidget()),
 ];
 
 const List<_Viewport> _viewports = [
@@ -101,20 +99,20 @@ Future<void> _pump(
   addTearDown(tester.view.resetDevicePixelRatio);
 
   await tester.pumpWidget(
-    MaterialApp(
-      theme: ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.brown,
-          brightness: brightness,
+    // Settings reads DarkModeProvider from the tree, exactly as main.dart
+    // supplies it.
+    ChangeNotifierProvider(
+      create: (_) => DarkModeProvider(),
+      child: MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.brown,
+            brightness: brightness,
+          ),
         ),
+        home: screen.build(),
       ),
-      home: screen.ownsScaffold
-          ? screen.build()
-          : Scaffold(
-              appBar: AppBar(title: Text(screen.name)),
-              body: screen.build(),
-            ),
     ),
   );
 


### PR DESCRIPTION
Closes the "known gap" in `docs/CI.md`: the render tests covered **4 screens**, now **17**, across three viewports and both themes — **108 cases**.

## What was blocking it

`FavoritesManager` and `QazaTrackerManager` hold `FirebaseFirestore`, `FirebaseAuth` and `FirebaseDatabase` instances in **field initialisers**, and `ItemList` builds a collection reference the same way. Constructing any of them threw `[core/no-app]`, which ruled out Favorites, Library, Qaza tracker and all eight zikr list screens.

## How it's answered

`test/ui/firebase_test_doubles.dart` handles both ways a screen reaches Firebase:

- **Construction** — `setupFirebaseCoreMocks()` + `Firebase.initializeApp()`, so the field initialisers succeed.
- **Calls** — mock handlers on the plugin channels returning empty results, so the reads screens kick off in `initState` take their "no data" path rather than raising `MissingPluginException` as an unhandled async error.

Screens render their empty state, which is what a new user sees and worth testing in its own right.

The screen list is now **`homeMenuItems` itself** rather than a copy, so a new menu entry is covered the day it's added and can't be forgotten.

`Qibla Finder` stays excluded, with the reason recorded next to the exclusion: it hosts a `WebViewWidget`, which asserts unless a `WebViewPlatform` is registered, and standing one up would test the stubs rather than the screen.

## A real bug it found immediately

Rendering **Settings** for the first time failed on a Flutter assertion:

> ListTile background color or ink splashes may be invisible. The ListTile is wrapped in a DecoratedBox that has a background color.

The section container is a `Container` with a background wrapping `ListTile` rows. `ListTile` paints its background and ink splashes onto the nearest `Material` ancestor — so **taps on every settings row landed with no ripple**.

Fixed by making the container a `Material` with a `shape`: same colour, radius and border, but now it's the ancestor the rows paint onto, and ink clips to the rounded corners.

That's the layer doing its job on its first full run.

## Verification

- `flutter test test/ui/page_render_test.dart` — **108 passed**
- `flutter analyze` — clean

Note for anyone running the full suite locally: `test/flight_prayer_times_test.dart` fails outside UTC. It's pre-existing on `master` and unrelated to this PR — `TZ=UTC flutter test` passes. Worth pinning the timezone in those tests separately.

---
_Generated by [Claude Code](https://claude.ai/code)_