### PR TITLE
Make the visual suite deterministic before committing baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,8 @@ web/zikr/
 test_visual/node_modules/
 test_visual/report/
 test_visual/test-results/
+
+# Playwright screenshot baselines: CI (linux) owns the enforced set.
+# A local run seeds one for its own platform; that is scratch, not a baseline.
+test_visual/specs/__screenshots__/*
+!test_visual/specs/__screenshots__/linux/

--- a/test_visual/playwright.config.js
+++ b/test_visual/playwright.config.js
@@ -7,7 +7,12 @@ const PORT = Number(process.env.PORT || 4173);
 module.exports = defineConfig({
   testDir: './specs',
   // One reviewable directory of committed baselines, split per viewport.
-  snapshotPathTemplate: '{testDir}/__screenshots__/{projectName}/{arg}{ext}',
+  // Keyed by platform on purpose. A Flutter canvas does not rasterise
+  // identically on macOS and Linux, so one shared baseline set would mean a
+  // developer's local run and CI could never both be right. CI owns the linux
+  // set; anything a local run seeds for its own platform is gitignored.
+  snapshotPathTemplate:
+    '{testDir}/__screenshots__/{platform}/{projectName}/{arg}{ext}',
   // The web app is one canvas; a hung frame fails slowly, so give it room.
   timeout: 90 * 1000,
   expect: {

--- a/test_visual/specs/app-shell.spec.js
+++ b/test_visual/specs/app-shell.spec.js
@@ -4,20 +4,29 @@ const {test, expect} = require('@playwright/test');
 const {
   assertNoFailures,
   bootFlutterApp,
-  expectScreenshot,
   watchForFailures,
 } = require('./helpers');
 
 // Routes the Flutter app itself has to render. Everything reachable only by
-// tapping inside the canvas is covered by the Dart golden tests in
-// test/golden/ — Playwright cannot address widgets inside a canvas reliably.
+// tapping inside the canvas is covered by the render tests in
+// test/ui/page_render_test.dart — Playwright cannot address widgets inside a
+// canvas reliably.
+//
+// These deliberately do not compare screenshots. The home screen shows a
+// randomly chosen hadith, so its height changes between loads and shifts
+// everything below it; a baseline would fail on the next run for reasons that
+// have nothing to do with the UI being broken. What is asserted instead — the
+// engine reaching first frame, a laid-out canvas, no console errors and no
+// same-origin 4xx — is deterministic and catches the failure that matters,
+// which is the page not rendering at all. Pixel comparison is kept for the
+// static HTML pages, which are stable.
 const APP_ROUTES = [
   {name: 'home', path: '/'},
   {name: 'delete-account', path: '/delete-account'},
 ];
 
 for (const route of APP_ROUTES) {
-  test(`${route.name} boots and paints a frame`, async ({page, baseURL}, testInfo) => {
+  test(`${route.name} boots and paints a frame`, async ({page, baseURL}) => {
     const failures = watchForFailures(page, baseURL);
 
     await bootFlutterApp(page, route.path);
@@ -33,8 +42,6 @@ for (const route of APP_ROUTES) {
     expect(canvasBox.height).toBeGreaterThan(100);
 
     assertNoFailures(failures);
-
-    await expectScreenshot(page, expect, testInfo, `${route.name}.png`);
   });
 }
 

--- a/test_visual/specs/helpers.js
+++ b/test_visual/specs/helpers.js
@@ -58,9 +58,13 @@ function watchForFailures(page, baseURL) {
   page.on('requestfailed', (request) => {
     const url = request.url();
     if (!url.startsWith(baseURL)) return;
-    failures.push(
-      `Request failed: ${url} (${request.failure()?.errorText ?? 'unknown'})`,
-    );
+    const error = request.failure()?.errorText ?? 'unknown';
+    // A cancelled request is not a broken asset. Flutter abandons font fetches
+    // it decides it no longer needs, and anything still in flight when the test
+    // ends aborts too — neither says the file is missing. A genuinely absent
+    // asset answers with a 404, which the response handler above catches.
+    if (error.includes('ERR_ABORTED')) return;
+    failures.push(`Request failed: ${url} (${error})`);
   });
 
   return failures;


### PR DESCRIPTION
Groundwork for enforcing screenshot baselines. Running the suite locally, repeatedly, surfaced three problems that would each have produced an intermittently red CI had baselines simply been committed.

## 1. Baselines weren't keyed by platform

A Flutter canvas doesn't rasterise identically on macOS and Linux, so one shared baseline set means a developer's local run and CI can never both be right. The snapshot path now includes `{platform}`. CI owns the `linux` set; anything a local run seeds for its own platform is gitignored.

## 2. The home screen cannot be pixel-compared at all

It shows a **randomly chosen hadith**, so its height changes between loads and shifts everything below it. The diff image was the entire page, ghosted.

Comparison is dropped for the two Flutter routes and kept for the static HTML pages, which are stable. What those tests still assert — first frame reached, a laid-out canvas, no console errors, no same-origin 4xx — is deterministic and catches the failure that actually matters, which is the page not rendering at all.

## 3. A cancelled request was reported as a broken asset

Flutter abandons font fetches it no longer needs, and anything in flight when a test ends aborts too, so `me_quran.ttf` intermittently failed a run with `net::ERR_ABORTED`. A genuinely missing asset answers 404, which the response handler already catches, so aborted requests are now ignored.

## Verification

Three consecutive full runs pass with no failures. Before these fixes the same suite failed 7, then 1, then 2 tests across consecutive runs.

## Next

Once this merges, CI seeds the `linux` baselines and uploads them as the `playwright-web` artifact. Committing those turns on enforced screenshot diffing for the static pages.

---
_Generated by [Claude Code](https://claude.ai/code)_