### PR TITLE
Release web prod on a pubspec version bump instead of a tag

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,7 +1,7 @@
 name: Web preview
 
 # Previews only. Production is deployed exclusively by web-release.yml, which
-# runs on a v* tag.
+# runs when the version in pubspec.yaml changes.
 on:
   push:
     branches:

--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -2,14 +2,24 @@ name: Web release
 
 # The only workflow that can write to the live site.
 #
-#   git tag v3.3.2 && git push origin v3.3.2
+#   node scripts/bump_version.js     # 3.3.2+95 -> 3.3.3+96
+#   git commit -am "Bump version to 3.3.3" && git push
+#
+# The version in pubspec.yaml is what cuts a release. A push to master is a
+# release when no `v<version>` tag exists yet; the tag is created by this
+# workflow after the deploy succeeds, so it records what is live rather than
+# what someone intended to ship. That is also what makes re-pushing a pubspec
+# change idempotent: an edit that leaves the version alone finds its tag
+# already there and stops at the gate.
 #
 # workflow_dispatch is kept for re-deploying an existing tag (a rollback is
 # just dispatching this workflow against an older tag).
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - master
+    paths:
+      - 'pubspec.yaml'
   workflow_dispatch:
     inputs:
       ref:
@@ -24,8 +34,53 @@ env:
   FLUTTER_VERSION: '3.44.8'
 
 jobs:
+  gate:
+    name: Decide whether this is a release
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.decide.outputs.release }}
+      tag: ${{ steps.decide.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Compare the pubspec version against the released tags
+        id: decide
+        run: |
+          set -euo pipefail
+          version=$(grep -m1 '^version:' pubspec.yaml | sed 's/version:[[:space:]]*//' | cut -d+ -f1)
+          tag="v$version"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Redeploying an existing tag. The checkout is that tag, so this
+            # still catches dispatching a ref whose pubspec says something else.
+            ref="${{ github.event.inputs.ref }}"
+            if [ "${ref#v}" != "$version" ]; then
+              echo "::error::Ref $ref does not match pubspec version $version."
+              exit 1
+            fi
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Redeploying $ref."
+            exit 0
+          fi
+
+          # Queried on the remote rather than in the checkout: the default
+          # checkout fetches no tags, and a stale local view would re-release a
+          # version that already shipped.
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "$tag already exists — pubspec.yaml changed without a version bump. Nothing to release."
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Releasing $tag."
+          fi
+
   verify:
     name: Verify release candidate
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -46,21 +101,12 @@ jobs:
       - name: Unit and widget tests
         run: flutter test --no-pub --reporter expanded
 
-      - name: Check the tag matches pubspec version
-        run: |
-          tag="${{ github.event.inputs.ref || github.ref_name }}"
-          pubspec=$(grep -m1 '^version:' pubspec.yaml | sed 's/version:[[:space:]]*//' | cut -d+ -f1)
-          if [ "${tag#v}" != "$pubspec" ]; then
-            echo "::error::Tag $tag does not match pubspec version $pubspec."
-            echo "Run scripts/bump_version.js, commit, then tag v$pubspec."
-            exit 1
-          fi
-          echo "Releasing $tag (pubspec $pubspec)."
-
   deploy:
     name: Deploy to production
-    needs: verify
+    needs: [gate, verify]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -87,10 +133,21 @@ jobs:
           target: shia-companion
           channelId: live
 
+      # Marks the commit that is actually live. Nothing triggers off this tag —
+      # the push trigger is branch-scoped — so it cannot start a second run.
+      - name: Tag the released commit
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ needs.gate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/$TAG"
+
       - name: Publish the deployed URL to the run summary
         if: always() && steps.live.outputs.details_url
         env:
-          TAG: "${{ github.event.inputs.ref || github.ref_name }}"
+          TAG: "${{ needs.gate.outputs.tag }}"
           URL: "${{ steps.live.outputs.details_url }}"
         run: |
           {

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | `ci.yml` | push to `master`, every PR, manual | Analysis, tests, web build + visual checks, Android APK, iOS build |
 | `web-preview.yml` | push to `master`, every PR, manual | Deploys a Firebase preview channel. Never touches production. |
-| `web-release.yml` | push of a `v*` tag, manual | The only workflow that writes to the live site |
+| `web-release.yml` | push to `master` that changes the version in `pubspec.yaml`, manual | The only workflow that writes to the live site |
 
 `ci.yml` runs analysis and tests first, on Ubuntu, and only starts the slow
 platform builds once they pass. A failing test is reported in about three
@@ -14,30 +14,38 @@ minutes instead of after a twenty minute build that was going to fail anyway.
 
 ## Releasing the web app
 
-Production is no longer deployed by merging to `master`. Merging deploys to the
-`staging` preview channel; production is cut from a tag:
+Merging an ordinary change to `master` deploys to the `staging` preview channel
+and nothing else. **The version in `pubspec.yaml` is what cuts a release:**
 
 ```bash
 node scripts/bump_version.js     # 3.3.1+94 -> 3.3.2+95
 git add pubspec.yaml && git commit -m "Bump version to 3.3.2"
 git push
-git tag v3.3.2 && git push origin v3.3.2
 ```
 
-`web-release.yml` then verifies the tag matches `pubspec.yaml`, re-runs
-analysis and tests, builds, runs the visual suite against the built bundle, and
-only then deploys to `live`.
+`web-release.yml` runs on any push to `master` touching `pubspec.yaml`, and its
+first job decides whether that push was actually a release: it is one when no
+`v<version>` tag exists yet. Editing `pubspec.yaml` without changing the version
+— adding a dependency, say — finds `v3.3.2` already there and stops at the gate,
+which is also what makes a re-push or a revert-and-redo harmless.
+
+Once past the gate it re-runs analysis and tests, builds, runs the visual suite
+against the built bundle, deploys to `live`, and only then tags the deployed
+commit `v3.3.2`. The tag is a record of what shipped rather than a trigger, so
+pushing one by hand no longer deploys anything.
 
 **Rolling back** is dispatching `web-release.yml` manually against an older tag.
+The gate checks that tag's own `pubspec.yaml` agrees with its name, and the
+tagging step is skipped since the tag already exists.
 
-**Nothing reaches production until a tag is pushed.** Merging to `master` moves
-`staging` and nothing else, so `https://shia-companion.web.app` can sit many
-merges behind `master` without anything looking wrong. This matters most for
-SEO: the pre-rendered `/zikr/<slug>` pages and the generated `sitemap.xml` only
-exist in a deployed bundle, so until a release tag ships them, Search Console
-keeps crawling the previous sitemap. Check the `live` row of
-`firebase hosting:channel:list` against the tag you expect before concluding
-anything about what Google can see.
+**Production still lags `master` between version bumps.** `staging` moves on
+every merge while `https://shia-companion.web.app` sits at the last released
+version, without anything looking wrong. This matters most for SEO: the
+pre-rendered `/zikr/<slug>` pages and the generated `sitemap.xml` only exist in
+a deployed bundle, so until a release ships them, Search Console keeps crawling
+the previous sitemap. Check the `live` row of `firebase hosting:channel:list`
+against the version you expect before concluding anything about what Google can
+see.
 
 ## SEO surface
 
@@ -76,7 +84,7 @@ mirrors the setting so the suite will tell you when they don't.
 
 | Channel | URL | Updated by | Lifetime |
 | --- | --- | --- | --- |
-| `live` | https://shia-companion.web.app | a `v*` tag | permanent |
+| `live` | https://shia-companion.web.app | a version bump in `pubspec.yaml` | permanent |
 | `staging` | https://shia-companion--staging-3dxo2xwu.web.app | every merge to `master` | 30 days, reset on each deploy |
 | per-PR | posted as a comment on the pull request | every push to the PR | 7 days |
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shia_companion
 description: All the features needed by the lovers of Ahle Bayt (may Allah's peace and blessings be upon them) in one app
 
-version: 3.3.3+96
+version: 3.3.4+97
 environment:
   sdk: ^3.0.0
 


### PR DESCRIPTION
Pushing a `v*` tag was a second, easily-forgotten step after the version bump it had to agree with, so production could sit many merges behind `master` with nothing looking wrong. The version in `pubspec.yaml` now drives the release.

## What changed

**Trigger.** `web-release.yml` runs on a push to `master` filtered to `paths: ['pubspec.yaml']`. The `push: tags: v*` trigger is gone.

**New `gate` job** decides whether that push was actually a release: it is one when no `v<version>` tag exists yet. An edit that leaves the version alone — adding a dependency, say — finds its tag already there and the run skips, which is also what makes a re-push or a revert-and-redo harmless. The check is `git ls-remote --tags origin` rather than a local lookup: the default checkout fetches no tags, so a local view would report every version as unreleased.

**Tagging moved to after a successful deploy**, on `$GITHUB_SHA` (needs `contents: write` on the deploy job). The tag now records what is live rather than triggering it. No recursion risk — the push trigger is branch-scoped, so a tag push cannot start a second run.

**The `workflow_dispatch` rollback path is unchanged.** Dispatching against an older tag still works; the old "tag matches pubspec" check moved into the gate, and the tagging step is skipped there since the tag already exists.

Docs updated: the trigger table, release section and `live` channel row in `docs/CI.md`, plus the stale "runs on a v* tag" comment in `web-preview.yml`.

## Consequence worth naming

Releases now fire without a separate confirming action — a merged PR carrying a version bump ships to production on merge. That is the intent, but if the gap is wanted back later, `environment: production` with a required reviewer on the deploy job is the cheap way to get it.

## Verification

Gate logic dry-run against the real repo: `pubspec.yaml` at 3.3.3 with `v3.3.3` on the remote resolves to `release=false`, correctly treating a non-bump pubspec edit as a no-op. All three workflows parse.

Bumps to **3.3.4+97**, so merging this exercises the new path and ships 3.3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
