### PR TITLE
Bump version to 3.3.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shia_companion
 description: All the features needed by the lovers of Ahle Bayt (may Allah's peace and blessings be upon them) in one app
 
-version: 3.3.3+96
+version: 3.3.4+97
 environment:
   sdk: ^3.0.0
 


### PR DESCRIPTION
Bumps `pubspec.yaml` from `3.3.3+96` to `3.3.4+97`, which is what triggers the web prod release.

Kept separate from #46 so the fix can be reviewed on its own and the release cut when you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)