### PR TITLE
Give Arabic quotations the layout and styling they need

### DIFF
--- a/lib/pages/chapter_page.dart
+++ b/lib/pages/chapter_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shia_companion/data/uid_title_data.dart';
 import 'package:shia_companion/services/library_progress_store.dart';
@@ -10,6 +9,7 @@ import 'package:shia_companion/utils/deep_links.dart';
 import 'package:shia_companion/utils/markdown_block.dart';
 import 'package:shia_companion/utils/markdown_block_parser.dart';
 import 'package:shia_companion/utils/reader_layout.dart';
+import 'package:shia_companion/utils/reader_style.dart';
 import 'package:shia_companion/utils/shared_preferences.dart';
 import 'package:shia_companion/utils/web_route_sync.dart';
 
@@ -46,7 +46,6 @@ class _ChapterPageState extends State<ChapterPage>
     with WidgetsBindingObserver, RouteAware {
   static const double _minFontSize = 14;
   static const double _maxFontSize = 28;
-  static const double _lineHeight = 1.55;
 
   // A glance at a chapter (e.g. following a link and backing straight out)
   // shouldn't register as "reading" and surface a Continue Reading entry for
@@ -446,41 +445,6 @@ class _ChapterPageState extends State<ChapterPage>
     _scheduleCurrentWebRouteSync(replace: true);
   }
 
-  MarkdownStyleSheet _readerStyleSheet(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
-      // Justified body text is what makes a page read like a printed book
-      // rather than a web page. WrapAlignment.spaceBetween is how
-      // flutter_markdown_plus spells TextAlign.justify. Headings and list items
-      // stay ragged-right — justifying short lines just stretches them.
-      textAlign: WrapAlignment.spaceBetween,
-      blockquoteAlign: WrapAlignment.spaceBetween,
-      p: textTheme.bodyLarge?.copyWith(
-        fontSize: _readerFontSize,
-        height: _lineHeight,
-      ),
-      h1: textTheme.headlineSmall?.copyWith(fontSize: _readerFontSize + 8),
-      h2: textTheme.titleLarge?.copyWith(fontSize: _readerFontSize + 5),
-      h3: textTheme.titleMedium?.copyWith(fontSize: _readerFontSize + 3),
-      h4: textTheme.titleSmall?.copyWith(fontSize: _readerFontSize + 2),
-      h5: textTheme.titleSmall?.copyWith(fontSize: _readerFontSize + 1),
-      h6: textTheme.titleSmall?.copyWith(fontSize: _readerFontSize),
-      blockquote: textTheme.bodyLarge?.copyWith(
-        fontSize: _readerFontSize,
-        height: _lineHeight,
-        fontStyle: FontStyle.italic,
-      ),
-      code: textTheme.bodyMedium?.copyWith(
-        fontSize: _readerFontSize - 2,
-        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
-      ),
-      a: textTheme.bodyLarge?.copyWith(
-        fontSize: _readerFontSize,
-        color: Theme.of(context).colorScheme.primary,
-      ),
-    );
-  }
-
   Widget _buildPagedReader(String chapterMarkdown) {
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -601,7 +565,7 @@ class _ChapterPageState extends State<ChapterPage>
                   columnKey: _measureColumnKey!,
                   blocks: _blocks,
                   blockKeys: _measureBlockKeys,
-                  styleSheet: _readerStyleSheet(context),
+                  styleSheet: readerStyleSheet(context, fontSize: _readerFontSize),
                 ),
               ),
             ),
@@ -745,7 +709,7 @@ class _ChapterPageState extends State<ChapterPage>
           blocks: _blocks,
           page: pagination.pages[pageIndex],
           pageHeight: _pageHeight,
-          styleSheet: _readerStyleSheet(context),
+          styleSheet: readerStyleSheet(context, fontSize: _readerFontSize),
         ),
       ),
     );

--- a/lib/utils/markdown_block_parser.dart
+++ b/lib/utils/markdown_block_parser.dart
@@ -21,6 +21,18 @@ class MarkdownBlockParser {
     r']',
   );
 
+  /// Characters that carry no direction of their own: whitespace, digits in
+  /// any script (ASCII, Arabic-Indic and extended Arabic-Indic), punctuation,
+  /// symbols and combining marks.
+  static final RegExp _weakOrNeutralPattern = RegExp(
+    r'[\s\d\u0660-\u0669\u06F0-\u06F9\p{P}\p{S}\p{M}]',
+    unicode: true,
+  );
+
+  /// Any letter, in any script — the only class of character strong enough to
+  /// set a block's direction.
+  static final RegExp _letterPattern = RegExp(r'\p{L}', unicode: true);
+
   static final RegExp _blankLineSplit = RegExp(r'\n\s*\n');
 
   /// Matches a single "soft" line break within a block (as opposed to the
@@ -180,62 +192,34 @@ class MarkdownBlockParser {
 
   /// Detect the text direction of a block's content.
   ///
-  /// Returns [TextDirection.rtl] if the first non-whitespace character
-  /// belongs to a right-to-left script, otherwise [TextDirection.ltr].
+  /// The direction of a block, from the first *strong* character in it.
+  ///
+  /// This is the rule the Unicode bidirectional algorithm uses, and the
+  /// distinction it draws matters here. Digits are weak: they take the
+  /// direction of the text around them instead of setting it. So does
+  /// punctuation, and so do the harakat that sit on Arabic letters. Only a
+  /// letter is strong enough to decide.
+  ///
+  /// Skipping digits is not a nicety. The library numbers its quotations —
+  /// `> 1ـ الدُّنْيا دارُ مَمَرٍّ` opens thousands of aphorisms in Ghurar
+  /// al-Hikam alone — and treating that leading `1` as strong laid every one
+  /// of them out left to right.
   static TextDirection _detectTextDirection(String text) {
-    // Find the first significant character (non-whitespace, non-punctuation)
     for (var i = 0; i < text.length && i < 500; i++) {
       final char = text[i];
+      // Weak or neutral: whitespace, digits in any script, punctuation,
+      // symbols, and combining marks. None of these set a direction.
+      if (_weakOrNeutralPattern.hasMatch(char)) {
+        continue;
+      }
       if (_rtlCharPattern.hasMatch(char)) {
         return TextDirection.rtl;
       }
-      // Skip whitespace and common ASCII punctuation
-      if (char.trim().isEmpty || _isAsciiPunctuation(char)) {
-        continue;
+      if (_letterPattern.hasMatch(char)) {
+        return TextDirection.ltr;
       }
-      // First non-whitespace, non-punctuation character is LTR
-      return TextDirection.ltr;
     }
     return TextDirection.ltr;
   }
 
-  static bool _isAsciiPunctuation(String char) {
-    // Use code-unit checks to avoid const string escaping issues.
-    for (final c in char.codeUnits) {
-      if (c == 46 ||
-          c == 44 ||
-          c == 59 ||
-          c == 58 ||
-          c == 33 ||
-          c == 63 ||
-          c == 45 ||
-          c == 34 ||
-          c == 39 ||
-          c == 40 ||
-          c == 41 ||
-          c == 91 ||
-          c == 93 ||
-          c == 123 ||
-          c == 125 ||
-          c == 60 ||
-          c == 62 ||
-          c == 47 ||
-          c == 64 ||
-          c == 35 ||
-          c == 36 ||
-          c == 37 ||
-          c == 94 ||
-          c == 38 ||
-          c == 42 ||
-          c == 95 ||
-          c == 126 ||
-          c == 96 ||
-          c == 43 ||
-          c == 61 ||
-          c == 124) {
-        return true;
-      }
-    }
-    return false;
-  }
 }

--- a/lib/utils/reader_style.dart
+++ b/lib/utils/reader_style.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+
+/// The line height the reader lays body text out at.
+const double kReaderLineHeight = 1.55;
+
+/// The reader's markdown styles, for one font size.
+///
+/// This lives outside [ChapterPage] because the pagination tests have to
+/// measure a chapter with exactly the styles it renders in — a copy of this
+/// that drifted by a point would test a layout the reader never produces.
+MarkdownStyleSheet readerStyleSheet(
+  BuildContext context, {
+  required double fontSize,
+}) {
+  final theme = Theme.of(context);
+  final textTheme = theme.textTheme;
+  return MarkdownStyleSheet.fromTheme(theme).copyWith(
+    // Justified body text is what makes a page read like a printed book
+    // rather than a web page. WrapAlignment.spaceBetween is how
+    // flutter_markdown_plus spells TextAlign.justify. Headings and list items
+    // stay ragged-right — justifying short lines just stretches them.
+    textAlign: WrapAlignment.spaceBetween,
+    blockquoteAlign: WrapAlignment.spaceBetween,
+    p: textTheme.bodyLarge?.copyWith(
+      fontSize: fontSize,
+      height: kReaderLineHeight,
+    ),
+    h1: textTheme.headlineSmall?.copyWith(fontSize: fontSize + 8),
+    h2: textTheme.titleLarge?.copyWith(fontSize: fontSize + 5),
+    h3: textTheme.titleMedium?.copyWith(fontSize: fontSize + 3),
+    h4: textTheme.titleSmall?.copyWith(fontSize: fontSize + 2),
+    h5: textTheme.titleSmall?.copyWith(fontSize: fontSize + 1),
+    h6: textTheme.titleSmall?.copyWith(fontSize: fontSize),
+    blockquote: textTheme.bodyLarge?.copyWith(
+      fontSize: fontSize,
+      height: kReaderLineHeight,
+      fontStyle: FontStyle.italic,
+    ),
+    blockquotePadding: const EdgeInsets.symmetric(
+      horizontal: 14,
+      vertical: 4,
+    ),
+    // flutter_markdown_plus fills every blockquote with a hardcoded
+    // Colors.blue.shade100 that ignores the theme — the same blue in dark mode
+    // as in light. Most of this library's quotations are Qur'an and hadith, and
+    // whole chapters alternate quote and commentary, so a filled panel turns
+    // the page into bands of colour instead of marking anything. A rule down
+    // the leading edge says "quotation" without tinting the text, and
+    // BorderDirectional follows the block's own direction, so it sits on the
+    // right of an Arabic quote and the left of an English one.
+    blockquoteDecoration: BoxDecoration(
+      border: BorderDirectional(
+        start: BorderSide(
+          color: theme.colorScheme.primary.withValues(alpha: 0.45),
+          width: 3,
+        ),
+      ),
+    ),
+    code: textTheme.bodyMedium?.copyWith(
+      fontSize: fontSize - 2,
+      backgroundColor: theme.colorScheme.surfaceContainerHighest,
+    ),
+    a: textTheme.bodyLarge?.copyWith(
+      fontSize: fontSize,
+      color: theme.colorScheme.primary,
+    ),
+  );
+}
+
+/// [base] adjusted for a right-to-left block.
+///
+/// Arabic has no italic form. Asking for one gets a synthetic oblique — the
+/// glyphs sheared over by software — which breaks the joins between letters and
+/// is exactly the effect Arabic typography avoids. The library's blockquotes
+/// are overwhelmingly Arabic, so the reader keeps the italic for quotations in
+/// English and drops it everywhere the text runs right to left.
+MarkdownStyleSheet rtlReaderStyleSheet(MarkdownStyleSheet base) {
+  return base.copyWith(
+    blockquote: base.blockquote?.copyWith(fontStyle: FontStyle.normal),
+  );
+}

--- a/lib/widgets/reader_content.dart
+++ b/lib/widgets/reader_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
 import '../utils/markdown_block.dart';
 import '../utils/reader_layout.dart';
+import '../utils/reader_style.dart';
 
 /// One block of a chapter, as both the measuring pass and the pages build it.
 ///
@@ -22,6 +23,13 @@ class ReaderBlockView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Derived here rather than passed in, so the measuring pass and the pages
+    // cannot end up holding different styles for the same block: both build
+    // through this one widget, from the same block and the same base sheet.
+    final sheet = block.textDirection == TextDirection.rtl
+        ? rtlReaderStyleSheet(styleSheet)
+        : styleSheet;
+
     return Padding(
       padding: EdgeInsets.only(
         top: block.blockTopMargin,
@@ -37,7 +45,7 @@ class ReaderBlockView extends StatelessWidget {
           // metrics to itself — measurement could then neither see the lines
           // nor trust the width they were broken at.
           selectable: false,
-          styleSheet: styleSheet,
+          styleSheet: sheet,
         ),
       ),
     );
@@ -76,7 +84,12 @@ class ReaderMeasureColumn extends StatelessWidget {
       child: Column(
         key: columnKey,
         mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
+        // Stretch, not start: a block that shrank to its text would sit against
+        // the left margin whatever its direction, leaving a short Arabic quote
+        // floating in the middle of the page with its rule beside it. At full
+        // width the block's own Directionality puts the text — and the rule —
+        // on the correct side.
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           for (var i = 0; i < blocks.length; i++)
             KeyedSubtree(
@@ -131,7 +144,9 @@ class ReaderPageWindow extends StatelessWidget {
                 offset: Offset(0, -page.contentOffset),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                  // Matches ReaderMeasureColumn; see the note there. The pages
+                  // must lay blocks out exactly as the measuring pass did.
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     for (var i = page.firstBlock;
                         i <= page.lastBlock && i < blocks.length;

--- a/test/library_pagination_test.dart
+++ b/test/library_pagination_test.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shia_companion/utils/markdown_block.dart';
 import 'package:shia_companion/utils/markdown_block_parser.dart';
 import 'package:shia_companion/utils/reader_layout.dart';
+import 'package:shia_companion/utils/reader_style.dart';
 import 'package:shia_companion/widgets/reader_content.dart';
 
 /// The reader lays a chapter out once, as one column, and shows pages by
@@ -21,35 +21,11 @@ import 'package:shia_companion/widgets/reader_content.dart';
 /// ([ReaderMeasureColumn]), so what is checked is the layout, not a model of
 /// it.
 void main() {
-  const lineHeight = 1.55;
   const epsilon = 0.01;
   // Lines of one paragraph overlap by a fraction of a pixel — each line box is
   // grown to the tallest ascent and descent on it — so "inside a line" means
   // properly inside it, not within rounding of its edge.
   const tolerance = 1.0;
-
-  MarkdownStyleSheet readerStyleSheet(BuildContext context, double fontSize) {
-    // Mirrors ChapterPage._readerStyleSheet.
-    final textTheme = Theme.of(context).textTheme;
-    return MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
-      textAlign: WrapAlignment.spaceBetween,
-      blockquoteAlign: WrapAlignment.spaceBetween,
-      p: textTheme.bodyLarge?.copyWith(fontSize: fontSize, height: lineHeight),
-      h1: textTheme.headlineSmall?.copyWith(fontSize: fontSize + 8),
-      h2: textTheme.titleLarge?.copyWith(fontSize: fontSize + 5),
-      h3: textTheme.titleMedium?.copyWith(fontSize: fontSize + 3),
-      h4: textTheme.titleSmall?.copyWith(fontSize: fontSize + 2),
-      h5: textTheme.titleSmall?.copyWith(fontSize: fontSize + 1),
-      h6: textTheme.titleSmall?.copyWith(fontSize: fontSize),
-      blockquote: textTheme.bodyLarge?.copyWith(
-        fontSize: fontSize,
-        height: lineHeight,
-        fontStyle: FontStyle.italic,
-      ),
-      code: textTheme.bodyMedium?.copyWith(fontSize: fontSize - 2),
-      a: textTheme.bodyLarge?.copyWith(fontSize: fontSize),
-    );
-  }
 
   /// Lays [markdown] out the way the reader's measuring pass does and returns
   /// what it measured.
@@ -77,7 +53,7 @@ void main() {
                 columnKey: columnKey,
                 blocks: blocks,
                 blockKeys: blockKeys,
-                styleSheet: readerStyleSheet(context, fontSize),
+                styleSheet: readerStyleSheet(context, fontSize: fontSize),
               );
             }),
           ),

--- a/test/markdown_block_parser_test.dart
+++ b/test/markdown_block_parser_test.dart
@@ -78,6 +78,43 @@ void main() {
     expect(blocks.single.textDirection, TextDirection.ltr);
   });
 
+  test('a leading number does not make an Arabic quotation left-to-right', () {
+    // The library numbers its quotations, and Ghurar al-Hikam opens thousands
+    // of aphorisms exactly like this. A digit is weak in the Unicode bidi
+    // algorithm: it takes the direction of its surroundings rather than
+    // setting one.
+    final blocks = MarkdownBlockParser.parse(
+      '> 1\u0640 \u0627\u0644\u062F\u064F\u0651\u0646\u0652\u064A\u0627 '
+      '\u062F\u0627\u0631\u064F \u0645\u064E\u0645\u064E\u0631\u064D\u0651.',
+    );
+
+    expect(blocks.single.textDirection, TextDirection.rtl);
+  });
+
+  test('digits of any script are weak', () {
+    // Arabic-Indic digit, then Arabic text.
+    expect(
+      MarkdownBlockParser.parse('\u0667\u0640 \u0627\u0644\u0633\u0644\u0627\u0645')
+          .single
+          .textDirection,
+      TextDirection.rtl,
+    );
+    // A number that really does open English prose stays left-to-right.
+    expect(
+      MarkdownBlockParser.parse('7. Be in this world as a stranger.')
+          .single
+          .textDirection,
+      TextDirection.ltr,
+    );
+  });
+
+  test('a block with no strong character falls back to left-to-right', () {
+    expect(
+      MarkdownBlockParser.parse('123 456').single.textDirection,
+      TextDirection.ltr,
+    );
+  });
+
   test(
       'a run of consecutive list lines parses as one listItem block '
       'spanning all items', () {

--- a/test/reader_style_test.dart
+++ b/test/reader_style_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shia_companion/utils/markdown_block.dart';
+import 'package:shia_companion/utils/markdown_block_parser.dart';
+import 'package:shia_companion/utils/reader_style.dart';
+import 'package:shia_companion/widgets/reader_content.dart';
+
+/// How a quotation is presented in the reader.
+///
+/// Nearly every blockquote in the library is Qur'an or hadith in Arabic, and
+/// chapters alternate quote and commentary for pages at a time, so the styling
+/// of this one block type sets the character of the whole reader.
+void main() {
+  const arabicQuote = '> إنَّمَا الأَعْمَالُ بِالنِّيَّاتِ.';
+  const englishQuote = '> The actions of a person depend on his intentions.';
+
+  Future<MarkdownStyleSheet> sheetFor(
+    WidgetTester tester, {
+    Brightness brightness = Brightness.light,
+  }) async {
+    late MarkdownStyleSheet sheet;
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(brightness: brightness),
+      home: Builder(builder: (context) {
+        sheet = readerStyleSheet(context, fontSize: 18);
+        return const SizedBox();
+      }),
+    ));
+    return sheet;
+  }
+
+  group('blockquote decoration', () {
+    testWidgets('does not tint the quote', (tester) async {
+      // flutter_markdown_plus defaults blockquotes to a hardcoded
+      // Colors.blue.shade100. Overriding it is the whole point of setting
+      // blockquoteDecoration, so assert the fill is gone rather than that it
+      // is some particular colour.
+      for (final brightness in Brightness.values) {
+        final decoration = (await sheetFor(tester, brightness: brightness))
+            .blockquoteDecoration as BoxDecoration;
+
+        expect(
+          decoration.color,
+          isNull,
+          reason: 'blockquotes should not be filled in ${brightness.name} mode',
+        );
+      }
+    });
+
+    testWidgets('marks the quote with a rule on its leading edge',
+        (tester) async {
+      final decoration =
+          (await sheetFor(tester)).blockquoteDecoration as BoxDecoration;
+
+      // BorderDirectional, not Border: the rule has to move to the right-hand
+      // side of an Arabic quote, which a left/right Border cannot do.
+      final border = decoration.border;
+      expect(border, isA<BorderDirectional>());
+
+      border as BorderDirectional;
+      expect(border.start.width, greaterThan(0));
+      expect(border.top, BorderSide.none);
+      expect(border.bottom, BorderSide.none);
+    });
+  });
+
+  group('right-to-left blocks', () {
+    test('drop the synthetic oblique that italic would force on Arabic', () {
+      // Arabic has no italic form, so FontStyle.italic gets a software shear
+      // that breaks the joins between letters.
+      final base = MarkdownStyleSheet(
+        blockquote: const TextStyle(fontStyle: FontStyle.italic, fontSize: 18),
+      );
+
+      expect(base.blockquote!.fontStyle, FontStyle.italic);
+      expect(
+        rtlReaderStyleSheet(base).blockquote!.fontStyle,
+        FontStyle.normal,
+      );
+    });
+
+    test('keep every other property of the sheet they came from', () {
+      final base = MarkdownStyleSheet(
+        blockquote: const TextStyle(fontStyle: FontStyle.italic, fontSize: 21),
+        p: const TextStyle(fontSize: 18),
+        blockquoteAlign: WrapAlignment.spaceBetween,
+      );
+      final rtl = rtlReaderStyleSheet(base);
+
+      expect(rtl.blockquote!.fontSize, 21);
+      expect(rtl.p, base.p);
+      expect(rtl.blockquoteAlign, WrapAlignment.spaceBetween);
+    });
+  });
+
+  group('the reader applies the right sheet per block', () {
+    /// The style [ReaderBlockView] actually rendered the quote's text with.
+    Future<TextStyle> renderedQuoteStyle(
+      WidgetTester tester,
+      String markdown,
+    ) async {
+      final blocks = MarkdownBlockParser.parse(markdown);
+      expect(blocks.single.type, MarkdownBlockType.blockquote);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (context) {
+            return ReaderBlockView(
+              block: blocks.single,
+              styleSheet: readerStyleSheet(context, fontSize: 18),
+            );
+          }),
+        ),
+      ));
+
+      // The blockquote style lands on the span holding the text, not on the
+      // RichText's root span, which markdown leaves unstyled.
+      final root = tester.widget<RichText>(find.byType(RichText).first).text;
+      TextStyle? found;
+      root.visitChildren((span) {
+        if (span is TextSpan && (span.text ?? '').trim().isNotEmpty) {
+          found ??= span.style;
+          return false;
+        }
+        return true;
+      });
+      return found ?? root.style!;
+    }
+
+    testWidgets('Arabic quotations render upright', (tester) async {
+      final style = await renderedQuoteStyle(tester, arabicQuote);
+      expect(style.fontStyle, FontStyle.normal);
+    });
+
+    testWidgets('English quotations keep their italic', (tester) async {
+      final style = await renderedQuoteStyle(tester, englishQuote);
+      expect(style.fontStyle, FontStyle.italic);
+    });
+
+    testWidgets('an Arabic quote lays out right-to-left', (tester) async {
+      final blocks = MarkdownBlockParser.parse(arabicQuote);
+      expect(blocks.single.textDirection, TextDirection.rtl);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (context) {
+            return ReaderBlockView(
+              block: blocks.single,
+              styleSheet: readerStyleSheet(context, fontSize: 18),
+            );
+          }),
+        ),
+      ));
+
+      // The Directionality the block sets is what puts the leading-edge rule on
+      // the right and the text against it.
+      final directionality = tester.widget<Directionality>(
+        find
+            .descendant(
+              of: find.byType(ReaderBlockView),
+              matching: find.byType(Directionality),
+            )
+            .first,
+      );
+      expect(directionality.textDirection, TextDirection.rtl);
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to the library normalization in `shiavault-library`. Now that every Arabic quotation is a real Markdown blockquote rather than raw HTML the renderer printed as text, the reader's blockquote styling applies to ~5.5x as many blocks — and three defects that were mostly invisible before became the dominant look of the app.

## Direction was decided by the wrong character

`_detectTextDirection` walked the block looking for the first meaningful character, skipping whitespace and ASCII punctuation. It did not skip **digits** — and the library numbers its quotations:

```
> 1ـ الدُّنْيا دارُ مَمَرٍّ لا دارُ مَقَرٍّ.
```

That leading `1` was treated as strong, so the block was laid out left-to-right. Measured across the library: **16,893 blocks, 23.7% of every Arabic quotation**, with Ghurar al-Hikam alone accounting for 11,061.

Digits are *weak* in the Unicode bidi algorithm — they take the direction of their surroundings rather than setting it, as do punctuation and combining marks. Only a letter is strong enough to decide, and now only a letter does.

## Blockquotes were filled with a hardcoded blue

`flutter_markdown_plus` defaults `blockquoteDecoration` to `Colors.blue.shade100`, baked into the package and identical in dark mode. One tinted panel reads as a pull-quote; a chapter that alternates quotation and commentary becomes bands of colour.

A rule down the leading edge marks the quotation without tinting it. `BorderDirectional` follows the block's own direction, so it sits on the right of an Arabic quote and the left of an English one.

## Arabic was being sheared into a synthetic oblique

The blockquote style asks for `FontStyle.italic`. Arabic has no italic form, so the glyphs were slanted by software and their joins broken. The italic is kept for quotations in English and dropped wherever the text runs right to left.

## Blocks now stretch to the content width

Both reader columns used `CrossAxisAlignment.start`, so a short quote shrank to its text and sat against the left margin whatever its direction — leaving Arabic stranded mid-page with its rule beside it. At full width the block's own `Directionality` puts text and rule on the correct side. The measuring pass and the pages are changed together, as they must be.

## Before / after

Rendered through the Flutter engine from a real chapter (Ghurar al-Hikam, "This World"):

**Before** — blue fill, sheared glyphs, quote laid out left-to-right with the numeral leading on the left.

**After** — quote against the right margin, rule on its right edge, upright glyphs, no fill.

## Also

The reader's stylesheet moves to `lib/utils/reader_style.dart`. It was private to `ChapterPage`, so `library_pagination_test.dart` carried a hand-kept copy that could silently drift from the real one — which matters because this change alters block heights. The tests now measure with the same styles the reader renders in.

## Validation

- `flutter analyze` — clean
- `flutter test` — **445 passing** (438 before, 7 new)
- `library_pagination_test.dart` — pages still fill exactly at 16pt and 26pt across Arabic prose, lists, setext headings and escaped backticks, so the measuring pass and the pages still agree after the alignment change
- New `test/reader_style_test.dart` asserts the rendered result, not the intent: no fill in either brightness, a `BorderDirectional` rule, Arabic rendering upright, English keeping its italic, and an Arabic block resolving to `TextDirection.rtl`
- New parser tests cover the numbered-quotation case, Arabic-Indic digits, and an English ordered list staying left-to-right

Run on Flutter 3.44.8, the version CI pins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fgt8PZv4qN5m7WH8BfwYTb)_