### PR TITLE
Add keyboard navigation to chapter reader with arrow keys

### DIFF
--- a/lib/pages/chapter_page.dart
+++ b/lib/pages/chapter_page.dart
@@ -818,10 +818,14 @@ class _ChapterPageState extends State<ChapterPage>
       );
     }
 
-    final label = forward ? 'Next chapter' : 'Previous chapter';
+    // One line, so the bar keeps its height as the reader crosses the edge,
+    // and short-prefixed, so the room goes to the part that identifies the
+    // chapter. The tooltip carries the untruncated title.
     return Flexible(
       child: Tooltip(
-        message: '$label: $chapterTitle',
+        message: forward
+            ? 'Next chapter: $chapterTitle'
+            : 'Previous chapter: $chapterTitle',
         child: TextButton.icon(
           onPressed: onPressed,
           icon: Icon(
@@ -833,25 +837,12 @@ class _ChapterPageState extends State<ChapterPage>
             padding: const EdgeInsets.symmetric(horizontal: 8),
             visualDensity: VisualDensity.compact,
           ),
-          label: Column(
-            crossAxisAlignment: forward
-                ? CrossAxisAlignment.end
-                : CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.labelSmall,
-              ),
-              Text(
-                chapterTitle,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.labelMedium,
-              ),
-            ],
+          label: Text(
+            forward ? 'Next: $chapterTitle' : 'Previous: $chapterTitle',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: forward ? TextAlign.end : TextAlign.start,
+            style: Theme.of(context).textTheme.labelLarge,
           ),
         ),
       ),

--- a/lib/pages/chapter_page.dart
+++ b/lib/pages/chapter_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shia_companion/data/uid_title_data.dart';
@@ -117,6 +118,11 @@ class _ChapterPageState extends State<ChapterPage>
 
   final Stopwatch _activeReadingTime = Stopwatch();
 
+  /// Holds the keyboard for the reader, so the arrow keys turn pages on web and
+  /// desktop instead of walking focus around the controls.
+  final FocusNode _keyboardFocusNode =
+      FocusNode(debugLabel: 'ChapterPage keyboard');
+
   @override
   void initState() {
     super.initState();
@@ -140,6 +146,7 @@ class _ChapterPageState extends State<ChapterPage>
       routeObserver.unsubscribe(this);
     }
     _pageController?.dispose();
+    _keyboardFocusNode.dispose();
     _saveProgress();
     super.dispose();
   }
@@ -782,6 +789,111 @@ class _ChapterPageState extends State<ChapterPage>
     }
   }
 
+  /// Turns pages from the keyboard. Arrow keys are what a reader on the web
+  /// reaches for, and they carry across a chapter boundary exactly as the
+  /// on-screen controls do.
+  KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (HardwareKeyboard.instance.isControlPressed ||
+        HardwareKeyboard.instance.isMetaPressed ||
+        HardwareKeyboard.instance.isAltPressed) {
+      return KeyEventResult.ignored;
+    }
+
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.arrowLeft ||
+        key == LogicalKeyboardKey.pageUp) {
+      if (!_canGoBack) return KeyEventResult.ignored;
+      _goToPreviousPage();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowRight ||
+        key == LogicalKeyboardKey.pageDown) {
+      if (!_canGoForward) return KeyEventResult.ignored;
+      _goToNextPage();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  /// The title of the chapter reading flows into, in [forward]'s direction, or
+  /// null when this is the first or last chapter of the book.
+  String? _adjacentChapterTitle({required bool forward}) {
+    if (forward ? !_hasNextChapter : !_hasPreviousChapter) return null;
+    return widget.chapters[_chapterIndex + (forward ? 1 : -1)].title;
+  }
+
+  /// The control at either end of the reader's toolbar.
+  ///
+  /// In the middle of a chapter it is an arrow, because there is nothing to say
+  /// beyond "one page further". On the edge pages the same press leaves the
+  /// chapter altogether, so the arrow becomes a labelled button naming the
+  /// chapter it lands in — nobody should have to guess that a chevron is about
+  /// to take them somewhere else.
+  Widget _buildPageNavControl({
+    required bool forward,
+    required int pageCount,
+  }) {
+    final atEdge = _paginationReady &&
+        (forward
+            ? _currentPageIndex >= pageCount - 1
+            : _currentPageIndex == 0);
+    final chapterTitle =
+        atEdge ? _adjacentChapterTitle(forward: forward) : null;
+    final onPressed = forward
+        ? (_canGoForward ? _goToNextPage : null)
+        : (_canGoBack ? _goToPreviousPage : null);
+
+    if (chapterTitle == null) {
+      return IconButton(
+        tooltip: forward ? 'Next page' : 'Previous page',
+        icon: Icon(forward ? Icons.chevron_right : Icons.chevron_left),
+        onPressed: onPressed,
+      );
+    }
+
+    final label = forward ? 'Next chapter' : 'Previous chapter';
+    return Flexible(
+      child: Tooltip(
+        message: '$label: $chapterTitle',
+        child: TextButton.icon(
+          onPressed: onPressed,
+          icon: Icon(
+            forward ? Icons.chevron_right : Icons.chevron_left,
+            size: 20,
+          ),
+          iconAlignment: forward ? IconAlignment.end : IconAlignment.start,
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            visualDensity: VisualDensity.compact,
+          ),
+          label: Column(
+            crossAxisAlignment: forward
+                ? CrossAxisAlignment.end
+                : CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelSmall,
+              ),
+              Text(
+                chapterTitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildMessage({
     required IconData icon,
     required String title,
@@ -818,122 +930,127 @@ class _ChapterPageState extends State<ChapterPage>
     final progress =
         pageCount <= 1 ? 1.0 : (_currentPageIndex + 1) / pageCount;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_title),
-        actions: [
-          if (bookSlug != null && bookSlug.trim().isNotEmpty) ...[
-            IconButton(
-              icon: _isSharing
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.share),
-              tooltip: 'Share chapter',
-              onPressed: _isSharing ? null : _shareChapter,
-            ),
-            IconButton(
-              icon: _isSaving
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : Icon(_isSaved ? Icons.download_done : Icons.download),
-              tooltip: _isSaved ? 'Remove offline copy' : 'Save book offline',
-              onPressed: _toggleSave,
-            ),
-          ],
-        ],
-      ),
-      body: FutureBuilder<String>(
-        future: _chapterFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return _buildMessage(
-              icon: Icons.cloud_off,
-              title: 'Chapter unavailable',
-              message: 'Check your connection and try again.',
-              actionLabel: 'Retry',
-              onAction: _retry,
-            );
-          }
-          return ResponsiveContent(
-            maxWidth: readingContentWidth,
-            padding: EdgeInsets.zero,
-            child: _buildPagedReader(snapshot.data ?? ''),
-          );
-        },
-      ),
-      bottomNavigationBar: SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            LinearProgressIndicator(
-              value: _paginationReady ? progress : null,
-              minHeight: 2,
-              backgroundColor: theme.dividerColor.withValues(alpha: 0.3),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(8, 6, 8, 10),
-              child: Row(
-                children: [
-                  IconButton(
-                    tooltip: _paginationReady &&
-                            _currentPageIndex == 0 &&
-                            _hasPreviousChapter
-                        ? 'Previous chapter'
-                        : 'Previous page',
-                    icon: const Icon(Icons.chevron_left),
-                    onPressed: _canGoBack ? _goToPreviousPage : null,
-                  ),
-                  if (_paginationReady)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 4),
-                      child: Text(
-                        '${_currentPageIndex + 1} / $pageCount',
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                    )
-                  else
-                    const SizedBox(width: 48),
-                  IconButton(
-                    tooltip: _paginationReady &&
-                            _currentPageIndex == pageCount - 1 &&
-                            _hasNextChapter
-                        ? 'Next chapter'
-                        : 'Next page',
-                    icon: const Icon(Icons.chevron_right),
-                    onPressed: _canGoForward ? _goToNextPage : null,
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    tooltip: 'Decrease font size',
-                    icon: const Icon(Icons.text_decrease),
-                    onPressed: _readerFontSize <= _minFontSize
-                        ? null
-                        : () => _changeFontSize(-1),
-                  ),
-                  Text(
-                    '${_readerFontSize.round()}',
-                    style: theme.textTheme.bodyMedium,
-                  ),
-                  IconButton(
-                    tooltip: 'Increase font size',
-                    icon: const Icon(Icons.text_increase),
-                    onPressed: _readerFontSize >= _maxFontSize
-                        ? null
-                        : () => _changeFontSize(1),
-                  ),
-                ],
+    return Focus(
+      focusNode: _keyboardFocusNode,
+      autofocus: true,
+      onKeyEvent: _onKeyEvent,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(_title),
+          actions: [
+            if (bookSlug != null && bookSlug.trim().isNotEmpty) ...[
+              IconButton(
+                icon: _isSharing
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.share),
+                tooltip: 'Share chapter',
+                onPressed: _isSharing ? null : _shareChapter,
               ),
-            ),
+              IconButton(
+                icon: _isSaving
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(_isSaved ? Icons.download_done : Icons.download),
+                tooltip: _isSaved ? 'Remove offline copy' : 'Save book offline',
+                onPressed: _toggleSave,
+              ),
+            ],
           ],
+        ),
+        body: FutureBuilder<String>(
+          future: _chapterFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (snapshot.hasError) {
+              return _buildMessage(
+                icon: Icons.cloud_off,
+                title: 'Chapter unavailable',
+                message: 'Check your connection and try again.',
+                actionLabel: 'Retry',
+                onAction: _retry,
+              );
+            }
+            return ResponsiveContent(
+              maxWidth: readingContentWidth,
+              padding: EdgeInsets.zero,
+              child: _buildPagedReader(snapshot.data ?? ''),
+            );
+          },
+        ),
+        bottomNavigationBar: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              LinearProgressIndicator(
+                value: _paginationReady ? progress : null,
+                minHeight: 2,
+                backgroundColor: theme.dividerColor.withValues(alpha: 0.3),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8, 6, 8, 10),
+                child: Row(
+                  children: [
+                    // The navigation controls take whatever room is left over
+                    // once the font controls have theirs: on an edge page they
+                    // grow into a labelled button, and the label is the part
+                    // that needs the space.
+                    Expanded(
+                      child: Row(
+                        children: [
+                          _buildPageNavControl(
+                            forward: false,
+                            pageCount: pageCount,
+                          ),
+                          if (_paginationReady)
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 4),
+                              child: Text(
+                                '${_currentPageIndex + 1} / $pageCount',
+                                style: theme.textTheme.bodyMedium,
+                              ),
+                            )
+                          else
+                            const SizedBox(width: 48),
+                          _buildPageNavControl(
+                            forward: true,
+                            pageCount: pageCount,
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: 'Decrease font size',
+                      icon: const Icon(Icons.text_decrease),
+                      onPressed: _readerFontSize <= _minFontSize
+                          ? null
+                          : () => _changeFontSize(-1),
+                    ),
+                    Text(
+                      '${_readerFontSize.round()}',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    IconButton(
+                      tooltip: 'Increase font size',
+                      icon: const Icon(Icons.text_increase),
+                      onPressed: _readerFontSize >= _maxFontSize
+                          ? null
+                          : () => _changeFontSize(1),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/test/ui/chapter_page_reader_test.dart
+++ b/test/ui/chapter_page_reader_test.dart
@@ -278,7 +278,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byType(TextButton),
-        matching: find.text('The Chapter Before'),
+        matching: find.text('Previous: The Chapter Before'),
       ),
       findsOneWidget,
       reason: 'the control should name the chapter it leads to',
@@ -298,7 +298,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byType(TextButton),
-        matching: find.text('The Chapter After'),
+        matching: find.text('Next: The Chapter After'),
       ),
       findsOneWidget,
     );

--- a/test/ui/chapter_page_reader_test.dart
+++ b/test/ui/chapter_page_reader_test.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -185,6 +186,127 @@ void main() {
       }, timeout: const Timeout(Duration(minutes: 5)));
     }
   }
+
+  /// Puts the reader on screen over [chapterSlug], paginated and ready.
+  Future<void> pumpReader(
+    WidgetTester tester, {
+    required String chapterSlug,
+    required List<UidTitleData> chapters,
+    required int chapterIndex,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: ChapterPage(
+        '$bookSlug/$chapterSlug',
+        'A Chapter',
+        bookSlug: bookSlug,
+        chapters: chapters,
+        chapterIndex: chapterIndex,
+        initialFontSize: 16,
+      ),
+    ));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets('the arrow keys turn pages', (tester) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const chapterSlug = 'arrow-keys';
+    seedChapter(chapterSlug, 'numbered_list.md');
+    await tester
+        .runAsync(() => LibraryService.loadChapterMarkdown('$bookSlug/$chapterSlug'));
+
+    await pumpReader(
+      tester,
+      chapterSlug: chapterSlug,
+      chapters: [UidTitleData(chapterSlug, 'A Chapter')],
+      chapterIndex: 0,
+    );
+    expect(readCounter(tester).page, 1);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(readCounter(tester).page, 2,
+        reason: 'the right arrow should turn to the next page');
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(readCounter(tester).page, 1,
+        reason: 'the left arrow should turn back a page');
+
+    expect(tester.takeException(), isNull);
+  }, timeout: const Timeout(Duration(minutes: 5)));
+
+  testWidgets('the edge pages name the chapter their control leads to',
+      (tester) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const chapterSlug = 'edge-pages';
+    const previousSlug = 'edge-pages-before';
+    const nextSlug = 'edge-pages-after';
+    for (final slug in [chapterSlug, previousSlug, nextSlug]) {
+      seedChapter(slug, 'numbered_list.md');
+      // Warmed so the reader's prefetch of its neighbours is a cache hit
+      // rather than a request the test would have to wait on.
+      await tester
+          .runAsync(() => LibraryService.loadChapterMarkdown('$bookSlug/$slug'));
+    }
+
+    await pumpReader(
+      tester,
+      chapterSlug: chapterSlug,
+      chapters: [
+        UidTitleData(previousSlug, 'The Chapter Before'),
+        UidTitleData(chapterSlug, 'A Chapter'),
+        UidTitleData(nextSlug, 'The Chapter After'),
+      ],
+      chapterIndex: 1,
+    );
+
+    // Page one: back leaves the chapter, so it says where it goes; forward is
+    // still just another page of this chapter. The controls are matched by
+    // tooltip — the chapter handoff page carries the same words in its text.
+    expect(find.byTooltip('Previous chapter: The Chapter Before'),
+        findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(TextButton),
+        matching: find.text('The Chapter Before'),
+      ),
+      findsOneWidget,
+      reason: 'the control should name the chapter it leads to',
+    );
+    expect(find.byTooltip('Next page'), findsOneWidget);
+    expect(find.byTooltip('Next chapter: The Chapter After'), findsNothing);
+
+    // Read to the last page, where it is the other way round.
+    final total = readCounter(tester).total;
+    for (var page = 1; page < total; page++) {
+      await tapToTurn(tester, Duration(seconds: page));
+      await tester.pumpAndSettle();
+    }
+    expect(readCounter(tester).page, total);
+
+    expect(find.byTooltip('Next chapter: The Chapter After'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(TextButton),
+        matching: find.text('The Chapter After'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byTooltip('Previous page'), findsOneWidget);
+    expect(find.byTooltip('Previous chapter: The Chapter Before'), findsNothing);
+
+    expect(tester.takeException(), isNull);
+  }, timeout: const Timeout(Duration(minutes: 5)));
 
   testWidgets('changing the font size re-cuts the pages and stays put',
       (tester) async {


### PR DESCRIPTION
## Summary
Adds keyboard support to the chapter reader, allowing users to navigate pages using arrow keys and Page Up/Page Down keys on web and desktop platforms. The navigation controls on edge pages now display the adjacent chapter name to clarify where navigation will lead.

## Key Changes
- **Keyboard event handling**: Added `_onKeyEvent` method to handle arrow keys (left/right) and Page Up/Down keys for page navigation, with modifier key filtering to avoid conflicts
- **Focus management**: Introduced `_keyboardFocusNode` to capture keyboard input at the chapter page level, properly disposed in cleanup
- **Smart navigation controls**: Refactored page navigation buttons into `_buildPageNavControl` method that:
  - Shows simple chevron icons for mid-chapter navigation
  - Displays labeled buttons with adjacent chapter names on edge pages
  - Provides clear tooltips indicating navigation destination
- **Helper method**: Added `_adjacentChapterTitle` to retrieve the chapter name in the navigation direction
- **UI restructuring**: Wrapped the Scaffold in a Focus widget to enable keyboard event capture while maintaining existing functionality
- **Test coverage**: Added comprehensive tests for arrow key navigation and edge page labeling behavior

## Implementation Details
- Keyboard input is only processed on KeyDown and KeyRepeat events; modifier keys (Ctrl, Meta, Alt) are ignored to prevent conflicts with system shortcuts
- Navigation respects existing `_canGoBack` and `_canGoForward` constraints
- Edge page detection uses pagination readiness and current page index to determine when to show chapter names
- The navigation control layout uses Flexible/Expanded to accommodate variable-width chapter name labels

https://claude.ai/code/session_01AUm8j6Xmi4SPMbQdShwm2e