### PR TITLE
Implement stable daily hadith seed for consistent "hadith of the day"

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
@@ -712,6 +713,7 @@ class _MyHomePageState extends State<MyHomePage>
     hadith = await loadRandomHadith(
       DefaultAssetBundle.of(context),
       useMuharramQuotes: useMuharramQuotes,
+      random: Random(dailyHadithSeed()),
     );
     if (!mounted) return;
     setState(() {});

--- a/lib/utils/hadith_loader.dart
+++ b/lib/utils/hadith_loader.dart
@@ -33,6 +33,15 @@ class HadithAssetLocation {
   final int itemIndex;
 }
 
+/// A seed that is stable for an entire UTC calendar day, so every user sees
+/// the same "hadith of the day" instead of a new random quote on every app
+/// launch. Pass [now] in tests to control which day is used.
+int dailyHadithSeed([DateTime? now]) {
+  final utcNow = (now ?? DateTime.now()).toUtc();
+  final dayStart = DateTime.utc(utcNow.year, utcNow.month, utcNow.day);
+  return dayStart.millisecondsSinceEpoch ~/ Duration.millisecondsPerDay;
+}
+
 HadithAssetLocation locateHadithAsset(int quoteIndex, int shardSize) {
   final shardIndex = quoteIndex ~/ shardSize;
   return HadithAssetLocation(

--- a/test/hadith_loader_test.dart
+++ b/test/hadith_loader_test.dart
@@ -45,4 +45,31 @@ void main() {
 
     expect(quote, isNotEmpty);
   });
+
+  test('daily seed is stable across the same UTC day and changes on the next',
+      () {
+    final morning = DateTime.utc(2026, 8, 22, 0, 30);
+    final night = DateTime.utc(2026, 8, 22, 23, 59);
+    final nextDay = DateTime.utc(2026, 8, 23, 0, 30);
+
+    expect(dailyHadithSeed(morning), dailyHadithSeed(night));
+    expect(dailyHadithSeed(morning), isNot(dailyHadithSeed(nextDay)));
+  });
+
+  test('same daily seed selects the same hadith index every time', () {
+    final seed = dailyHadithSeed(DateTime.utc(2026, 8, 22));
+
+    final first = selectHadithIndex(
+      manifest,
+      useMuharramQuotes: false,
+      random: Random(seed),
+    );
+    final second = selectHadithIndex(
+      manifest,
+      useMuharramQuotes: false,
+      random: Random(seed),
+    );
+
+    expect(first, second);
+  });
 }


### PR DESCRIPTION
## Summary
This PR implements a stable daily seed mechanism to ensure all users see the same "hadith of the day" throughout a UTC calendar day, rather than getting a new random hadith on every app launch.

## Key Changes
- **Added `dailyHadithSeed()` function** in `hadith_loader.dart` that generates a stable seed based on the current UTC date. The seed remains constant throughout a calendar day and changes only when the UTC date changes.
- **Updated `loadRandomHadith()` call** in `home_page.dart` to use the daily seed via `Random(dailyHadithSeed())` instead of relying on the default random behavior.
- **Added comprehensive test coverage** with two new tests:
  - Verifies that the daily seed is stable across the same UTC day (morning and night produce the same seed)
  - Verifies that the seed changes on the next UTC day
  - Verifies that using the same seed produces deterministic hadith selection

## Implementation Details
- The seed is calculated by converting the current datetime to UTC, extracting the date components, and dividing the milliseconds since epoch by milliseconds per day to create a compact, date-based seed value.
- The function accepts an optional `DateTime` parameter for testability, allowing tests to control which day is used without mocking the system clock.
- This ensures a consistent user experience where the "hadith of the day" feature works as intended across all users and app launches within the same day.

https://claude.ai/code/session_01FiX4xxiWvb6W11RQTkugEy